### PR TITLE
Rediseño de Home en Compose, soporte de Álbumes y notificación en segundo plano

### DIFF
--- a/app/src/main/java/com/example/pulseplayer/MainActivity.kt
+++ b/app/src/main/java/com/example/pulseplayer/MainActivity.kt
@@ -49,8 +49,9 @@ class MainActivity : ComponentActivity() {
                     }
                 },
                 onAppForegrounded = {
+                    stopService(Intent(this, MusicPlayerService::class.java))
                     val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-                    manager.cancel(1) // Oculta la notificación al volver a la app
+                    manager.cancel(1)
                 }
             )
         )

--- a/app/src/main/java/com/example/pulseplayer/NavController.kt
+++ b/app/src/main/java/com/example/pulseplayer/NavController.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.example.pulseplayer.data.entity.Song
+import com.example.pulseplayer.views.AlbumsScreen
 import com.example.pulseplayer.views.MenuScreen
 import com.example.pulseplayer.views.MusicScreen
 import com.example.pulseplayer.views.favorite.FavoriteScreen
@@ -27,6 +28,9 @@ object Menu
 // MUSICA
 @Serializable
 object Music
+
+@Serializable
+object Albums
 
 @Serializable
 data class NowPlaying(val songId: Int, val songIds: List<Int> )
@@ -65,6 +69,9 @@ fun Navigation(songs: List<Song>){
         }
         composable<Music> {
             MusicScreen(navController = navController) // ✅ corregido
+        }
+        composable<Albums> {
+            AlbumsScreen(navController = navController)
         }
         composable<NowPlaying> { backStackEntry ->
             val args = backStackEntry.toRoute<NowPlaying>()

--- a/app/src/main/java/com/example/pulseplayer/ui/components/MiniPlayerBar.kt
+++ b/app/src/main/java/com/example/pulseplayer/ui/components/MiniPlayerBar.kt
@@ -1,6 +1,7 @@
 package com.example.pulseplayer.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -9,17 +10,18 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.outlined.FastForward
+import androidx.compose.material.icons.outlined.FastRewind
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -33,7 +35,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.navigation.NavController
@@ -47,7 +48,6 @@ fun MiniPlayerBar(navController: NavController, modifier: Modifier = Modifier) {
     val currentSong = remember { mutableStateOf(ExoPlayerManager.getCurrentSong()) }
     val isPlaying = remember { mutableStateOf(ExoPlayerManager.getPlayer()?.isPlaying == true) }
 
-    // Listener de cambios en reproducción
     DisposableEffect(Unit) {
         val player = ExoPlayerManager.getPlayer()
         val listener = object : Player.Listener {
@@ -61,70 +61,53 @@ fun MiniPlayerBar(navController: NavController, modifier: Modifier = Modifier) {
             }
         }
         player?.addListener(listener)
-
-        onDispose {
-            player?.removeListener(listener)
-        }
+        onDispose { player?.removeListener(listener) }
     }
-
 
     val song = currentSong.value ?: return
 
-    Box(
+    Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(72.dp)
-            .background(
-                MaterialTheme.colorScheme.primary
-            )
-            .clickable {
-                navController.navigate(
-                    NowPlaying(song.idSong, listOf(song.idSong))
-                )
-            }
-            .padding(start = 12.dp, top = 8.dp, end = 12.dp, bottom = 8.dp),
-        contentAlignment = Alignment.CenterStart
+            .height(74.dp)
+            .clip(RoundedCornerShape(18.dp))
+            .background(Brush.horizontalGradient(listOf(Color(0xFF171A2C), Color(0xFF121527))))
+            .border(1.dp, Color.White.copy(alpha = 0.08f), RoundedCornerShape(18.dp))
+            .clickable { navController.navigate(NowPlaying(song.idSong, listOf(song.idSong))) }
+            .padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            AsyncImage(
-                model = song.coverImage?.ifEmpty { R.drawable.ic_music_placeholder },
-                contentDescription = null,
-                modifier = Modifier
-                    .size(48.dp)
-                    .clip(RoundedCornerShape(8.dp)),
-                contentScale = ContentScale.Crop
-            )
+        AsyncImage(
+            model = song.coverImage?.ifEmpty { R.drawable.ic_music_placeholder },
+            contentDescription = null,
+            modifier = Modifier.size(48.dp).clip(RoundedCornerShape(12.dp)),
+            contentScale = ContentScale.Crop
+        )
 
-            Spacer(modifier = Modifier.width(12.dp))
+        Spacer(Modifier.width(10.dp))
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.Center) {
+            Text(song.title, color = Color.White, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Text(song.artistName, color = Color.White.copy(alpha = 0.6f), maxLines = 1, overflow = TextOverflow.Ellipsis)
+        }
 
-            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.Center) {
-                Text(
-                    song.title,
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-//                    modifier = Modifier.offset(y = (3).dp)
-                )
-                Text(
-                    text = song.artistName,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-//                    modifier = Modifier.offset(y = (-3).dp)
-                )
-            }
-
+        IconButton(onClick = { ExoPlayerManager.playPrevious() }) {
+            Icon(Icons.Outlined.FastRewind, contentDescription = null, tint = Color.White.copy(alpha = 0.7f))
+        }
+        Box(
+            modifier = Modifier
+                .size(42.dp)
+                .clip(CircleShape)
+                .background(Brush.linearGradient(listOf(Color(0xFF7C3AED), Color(0xFF4F46E5)))),
+            contentAlignment = Alignment.Center
+        ) {
             IconButton(onClick = {
                 if (isPlaying.value) ExoPlayerManager.pause() else ExoPlayerManager.resume()
             }) {
-                Icon(
-                    imageVector = if (isPlaying.value) Icons.Default.Pause else Icons.Default.PlayArrow,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimary,
-                )
+                Icon(if (isPlaying.value) Icons.Rounded.Pause else Icons.Rounded.PlayArrow, contentDescription = null, tint = Color.White)
             }
+        }
+        IconButton(onClick = { ExoPlayerManager.playNext() }) {
+            Icon(Icons.Outlined.FastForward, contentDescription = null, tint = Color.White.copy(alpha = 0.7f))
         }
     }
 }

--- a/app/src/main/java/com/example/pulseplayer/views/AlbumsScreen.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/AlbumsScreen.kt
@@ -1,0 +1,105 @@
+package com.example.pulseplayer.views
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Album
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.pulseplayer.NowPlaying
+import com.example.pulseplayer.ui.components.MiniPlayerBar
+import com.example.pulseplayer.views.viewmodel.PlayerViewModel
+import com.example.pulseplayer.views.viewmodel.SongViewModel
+
+@Composable
+fun AlbumsScreen(navController: NavController) {
+    val songViewModel: SongViewModel = viewModel()
+    val playerViewModel: PlayerViewModel = viewModel()
+    val songs by songViewModel.allSongs.collectAsState()
+
+    val albums = songs
+        .groupBy { it.album?.trim().takeUnless { it.isNullOrEmpty() } ?: "Sin álbum" }
+        .map { (album, albumSongs) -> album to albumSongs.sortedBy { it.trackNumber?.toIntOrNull() ?: Int.MAX_VALUE } }
+        .sortedBy { it.first.lowercase() }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Álbumes", color = Color.White) },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF090B1A))
+            )
+        },
+        bottomBar = {
+            MiniPlayerBar(navController = navController, modifier = Modifier.fillMaxWidth())
+        },
+        containerColor = Color(0xFF060911)
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color(0xFF060911))
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            items(albums) { (album, albumSongs) ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            if (albumSongs.isNotEmpty()) {
+                                playerViewModel.playPlaylist(albumSongs, 0)
+                                navController.navigate(NowPlaying(albumSongs.first().idSong, albumSongs.map { it.idSong }))
+                            }
+                        },
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color.Transparent)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(Brush.horizontalGradient(listOf(Color(0xFF172554), Color(0xFF1E1B4B))))
+                            .padding(14.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(Icons.Outlined.Album, contentDescription = null, tint = Color(0xFFA78BFA))
+                        Column(modifier = Modifier.padding(start = 12.dp).weight(1f)) {
+                            Text(album, color = Color.White, style = MaterialTheme.typography.titleMedium)
+                            Text("${albumSongs.size} canciones", color = Color.White.copy(alpha = 0.65f))
+                        }
+                        Text(
+                            text = albumSongs.firstOrNull()?.artistName ?: "",
+                            color = Color.White.copy(alpha = 0.55f),
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/pulseplayer/views/menu.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/menu.kt
@@ -1,257 +1,283 @@
 package com.example.pulseplayer.views
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.outlined.AccessTime
+import androidx.compose.material.icons.outlined.Album
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.LibraryMusic
+import androidx.compose.material.icons.outlined.QueueMusic
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.rounded.GraphicEq
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.example.pulseplayer.Albums
 import com.example.pulseplayer.FavoriteScreen
 import com.example.pulseplayer.Music
 import com.example.pulseplayer.PlaybackHistoryScreen
 import com.example.pulseplayer.PlaylistScreen
-import com.example.pulseplayer.R
-import com.example.pulseplayer.isLandscape
 import com.example.pulseplayer.ui.components.MiniPlayerBar
-import org.burnoutcrew.reorderable.ReorderableItem
-import org.burnoutcrew.reorderable.detectReorderAfterLongPress
-import org.burnoutcrew.reorderable.rememberReorderableLazyGridState
-import org.burnoutcrew.reorderable.reorderable
+import com.example.pulseplayer.views.viewmodel.PlaylistViewModel
+import com.example.pulseplayer.views.viewmodel.SongViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MenuScreen(navController: NavController) {
-    //orientacion de la pantalla
-    val landscape = isLandscape()
+    val songViewModel: SongViewModel = viewModel()
+    val playlistViewModel: PlaylistViewModel = viewModel()
+    val songs by songViewModel.allSongs.collectAsState()
+    val playlists by playlistViewModel.playlists.collectAsState()
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = stringResource(R.string.app_name),
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primary
-                )
+    val albumCount = songs.map { it.album?.trim().orEmpty() }
+        .filter { it.isNotEmpty() }
+        .distinct()
+        .size
+
+    val categories = listOf(
+        LibraryCategory("Álbumes", "$albumCount álbumes", Icons.Outlined.Album, Color(0xFF8B5CF6)) { navController.navigate(Albums) },
+        LibraryCategory("Listas", "${playlists.size} listas", Icons.Outlined.QueueMusic, Color(0xFF60A5FA)) { navController.navigate(PlaylistScreen) },
+        LibraryCategory("Historial", "Recientes", Icons.Outlined.AccessTime, Color(0xFF34D399)) { navController.navigate(PlaybackHistoryScreen) },
+        LibraryCategory("Favoritos", "${songs.count { it.isFavorite }} canciones", Icons.Outlined.FavoriteBorder, Color(0xFFFB7185)) { navController.navigate(FavoriteScreen) }
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Brush.verticalGradient(listOf(Color(0xFF090B1A), Color(0xFF05060D))))
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(horizontal = 20.dp)
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            HomeHeader()
+            HeroMusicCard(onClick = { navController.navigate(Music) })
+
+            Text(
+                text = "BIBLIOTECA",
+                color = Color.White.copy(alpha = 0.4f),
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 13.sp,
+                modifier = Modifier.padding(top = 18.dp, bottom = 10.dp)
             )
-        },
-        bottomBar = {
+
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                userScrollEnabled = false,
+                modifier = Modifier.height(270.dp)
+            ) {
+                items(categories.size) { index ->
+                    CategoryCard(categories[index])
+                }
+            }
+
             MiniPlayerBar(
                 navController = navController,
-                modifier = Modifier.fillMaxWidth().wrapContentHeight().navigationBarsPadding(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp)
             )
-        },
-        containerColor = MaterialTheme.colorScheme.background,
-    ) { innerPadding ->
-        val modifier = Modifier.fillMaxSize().padding(innerPadding).padding(20.dp)
 
-        if (landscape) {
-            Row(
-                modifier = modifier,
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                //musiccard a la izquierda
-                Column(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight(),
-                    verticalArrangement = Arrangement.Top
-                ) {
-                    MusicCard(
-                        title = stringResource(R.string.title_music),
-                        icon = Icons.Default.MusicNote,
-                        colors = listOf(Color(0xFFFF416C), Color(0xFFFF4B2B)),
-                        onClick = { navController.navigate(Music) },
-                        modifier = Modifier
-                            .height(200.dp)
-                            .fillMaxWidth()
-                    )
-                }
-                //categorias ordenables a la derecha
-                Column(
-                    modifier = Modifier
-                        .weight(2f)
-                        .fillMaxHeight()
-                ) {
-                    ReorderableCategorySection(navController = navController)
-                }
-            }
-        } else {
-            Column(
-                modifier = modifier,
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                MusicCard(
-                    title = stringResource(R.string.title_music),
-                    icon = Icons.Default.MusicNote,
-                    colors = listOf(Color(0xFFFF416C), Color(0xFFFF4B2B)),
-                    onClick = { navController.navigate(Music) }
-                )
-
-                ReorderableCategorySection(navController = navController)
-
-            }
+            BottomNavStrip(
+                onHomeClick = {},
+                onSearchClick = { navController.navigate(Music) },
+                onLibraryClick = { navController.navigate(Albums) },
+                modifier = Modifier.padding(top = 16.dp)
+            )
         }
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 4.dp)
+                .width(132.dp)
+                .height(4.dp)
+                .clip(CircleShape)
+                .background(Color.White.copy(alpha = 0.2f))
+        )
     }
 }
 
 @Composable
-fun MusicCard(
-    title: String,
-    icon: ImageVector,
-    colors: List<Color>,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-        .fillMaxWidth()
-        .height(100.dp)) {
-    Box(
-        modifier = modifier
-            .background(
-                brush = Brush.horizontalGradient(colors),
-                shape = RoundedCornerShape(16.dp)
-            )
-            .clickable(onClick = onClick),
-        contentAlignment = Alignment.Center
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = Color.White,
-                modifier = Modifier.size(36.dp)
-            )
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onPrimary,
-            )
-        }
-    }
-}
-
-@Composable
-fun CategoryCard(
-    title: String,
-    iconId: Int,
-    colors: List<Color>,
-    modifier: Modifier,
-    onClick: () -> Unit
-){
-    Box(
-        modifier = modifier
-            .height(100.dp)
-            .background(
-                brush = Brush.horizontalGradient(colors),
-                shape = RoundedCornerShape(16.dp)
-            )
-            .clickable { onClick() },  // ✅ ejecuta el onClick real
-        contentAlignment = Alignment.Center
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Icon(
-                painter = painterResource(id = iconId),
-                contentDescription = null,
-                tint = Color.White,
-                modifier = Modifier.size(36.dp)
-            )
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.onPrimary,
-            )
-        }
-    }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-fun ReorderableCategorySection(navController: NavController) {
-    val items = remember { mutableStateListOf("Álbumes", "Listas", "Historial", "Favorito") }
-    val landscape = isLandscape()
-
-    val state = rememberReorderableLazyGridState(onMove = { from, to ->
-        val item = items.removeAt(from.index)
-        items.add(to.index, item)
-    })
-
-    val columns = if (landscape) 3 else 2 //si es horizontal 3 columnas, si es vertical 2
-
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(columns),
-        state = state.gridState,
+private fun HomeHeader() {
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(if (landscape) 200.dp else 240.dp)
-            .reorderable(state)
-            .detectReorderAfterLongPress(state),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        contentPadding = PaddingValues(bottom = 8.dp)
+            .padding(top = 8.dp, bottom = 20.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        items(items.size, { items[it] }) { index ->
-            val title = items[index]
-            ReorderableItem(state, key = title) {
-                val cardModifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(if (landscape) 1.5f else 2f)
-                    .animateItemPlacement()
-
-                CategoryCardDynamic(title = title, modifier = cardModifier, navController = navController)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(Brush.linearGradient(listOf(Color(0xFF7C3AED), Color(0xFF4F46E5)))),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(Icons.Rounded.GraphicEq, contentDescription = null, tint = Color.White)
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .size(10.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFF4ADE80))
+                        .border(2.dp, Color(0xFF090B1A), CircleShape)
+                )
             }
+            Spacer(Modifier.width(12.dp))
+            Column {
+                Text("Pulse Player", color = Color.White, fontWeight = FontWeight.Bold, fontSize = 28.sp)
+                Text("Reproductor Local", color = Color.White.copy(alpha = 0.45f), fontSize = 13.sp)
+            }
+        }
+
+        IconButton(
+            onClick = {},
+            modifier = Modifier
+                .size(42.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(Color.White.copy(alpha = 0.06f))
+                .border(1.dp, Color.White.copy(alpha = 0.08f), RoundedCornerShape(12.dp))
+        ) {
+            Icon(Icons.Outlined.Settings, contentDescription = null, tint = Color.White.copy(alpha = 0.7f))
         }
     }
 }
 
 @Composable
-fun CategoryCardDynamic(
-    title: String,
-    modifier: Modifier = Modifier,
-    navController: NavController? = null
-) {
-    val (iconId, colors) = when (title) {
-        "Álbumes" -> R.drawable.ic_album to listOf(Color(0xFF2193b0), Color(0xFF6dd5ed))
-        "Listas" -> R.drawable.ic_category to listOf(Color(0xFF56ab2f), Color(0xFFA8E063))
-        "Historial" -> R.drawable.ic_history to listOf(Color(0xFF7F00FF), Color(0xFFE100FF))
-        "Favorito" -> R.drawable.ic_favorite to listOf(Color(0xFFff6a00), Color(0xFFee0979))
-        else -> R.drawable.ic_album to listOf(Color.Gray, Color.LightGray)
-    }
-
-    val onClick: () -> Unit = {
-        when (title) {
-            "Listas" -> navController?.navigate(PlaylistScreen)
-            "Historial" -> navController?.navigate(PlaybackHistoryScreen)
-            "Favorito" -> navController?.navigate(FavoriteScreen) // 🔸 Aquí se agregó
-            else -> {}
+private fun HeroMusicCard(onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(210.dp)
+            .clip(RoundedCornerShape(26.dp))
+            .background(Brush.linearGradient(listOf(Color(0xFF5B21B6), Color(0xFF1E3A8A), Color(0xFF0F172A))))
+            .clickable(onClick = onClick)
+            .padding(24.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Box(
+                modifier = Modifier
+                    .size(66.dp)
+                    .clip(RoundedCornerShape(20.dp))
+                    .background(Color.White.copy(alpha = 0.12f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(Icons.Rounded.MusicNote, contentDescription = null, tint = Color.White, modifier = Modifier.size(34.dp))
+            }
+            Text("Música", color = Color.White, fontSize = 42.sp, fontWeight = FontWeight.Bold, modifier = Modifier.padding(top = 10.dp))
+            Text("Explorar biblioteca", color = Color.White.copy(alpha = 0.6f), fontSize = 15.sp)
         }
     }
+}
 
-    CategoryCard(
-        title = title,
-        iconId = iconId,
-        colors = colors,
-        modifier = modifier,
-        onClick = onClick
-    )
+data class LibraryCategory(
+    val title: String,
+    val subtitle: String,
+    val icon: ImageVector,
+    val color: Color,
+    val onClick: () -> Unit
+)
+
+@Composable
+private fun CategoryCard(item: LibraryCategory) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(Brush.linearGradient(listOf(Color(0xFF13203C), Color(0xFF0A132B))))
+            .border(1.dp, Color.White.copy(alpha = 0.06f), RoundedCornerShape(18.dp))
+            .clickable(onClick = item.onClick)
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(item.color.copy(alpha = 0.16f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(item.icon, contentDescription = null, tint = item.color)
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        Text(item.title, color = Color.White, fontWeight = FontWeight.SemiBold)
+        Text(item.subtitle, color = Color.White.copy(alpha = 0.45f), fontSize = 13.sp)
+    }
+}
+
+@Composable
+private fun BottomNavStrip(
+    onHomeClick: () -> Unit,
+    onSearchClick: () -> Unit,
+    onLibraryClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp),
+        horizontalArrangement = Arrangement.SpaceAround,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        BottomNavItem("Inicio", Icons.Outlined.Home, true, onHomeClick)
+        BottomNavItem("Buscar", Icons.Outlined.Search, false, onSearchClick)
+        BottomNavItem("Biblioteca", Icons.Outlined.LibraryMusic, false, onLibraryClick)
+    }
+}
+
+@Composable
+private fun BottomNavItem(label: String, icon: ImageVector, selected: Boolean, onClick: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.clickable(onClick = onClick).padding(4.dp)
+    ) {
+        Icon(icon, contentDescription = label, tint = if (selected) Color(0xFF8B5CF6) else Color.White.copy(alpha = 0.38f))
+        Text(
+            text = label,
+            color = if (selected) Color(0xFF8B5CF6) else Color.White.copy(alpha = 0.38f),
+            fontSize = 12.sp,
+            textAlign = TextAlign.Center
+        )
+    }
 }

--- a/app/src/main/java/com/example/pulseplayer/views/service/MusicPlayerService.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/service/MusicPlayerService.kt
@@ -1,6 +1,10 @@
 package com.example.pulseplayer.views.service
 
-import android.app.*
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -8,9 +12,6 @@ import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Build
 import android.os.IBinder
-import android.util.Log
-import android.widget.RemoteViews
-import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.media.app.NotificationCompat.MediaStyle
@@ -19,50 +20,45 @@ import androidx.media3.common.Player
 import com.example.pulseplayer.MainActivity
 import com.example.pulseplayer.R
 import com.example.pulseplayer.views.player.ExoPlayerManager
-import java.io.File
 
 class MusicPlayerService : Service() {
 
     override fun onCreate() {
         super.onCreate()
-        Log.d("MusicPlayerService", "✅ onCreate llamado")
-        // ✅ accede al player correctamente
         ExoPlayerManager.getPlayer()?.addListener(object : Player.Listener {
-
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-                showCustomNotification()
+                showPlayerNotification()
             }
 
             override fun onIsPlayingChanged(isPlaying: Boolean) {
-                showCustomNotification()
+                showPlayerNotification()
             }
         })
         createNotificationChannel()
-        showCustomNotification()
+        showPlayerNotification()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
-            "ACTION_PLAY" -> ExoPlayerManager.resume()
-            "ACTION_PAUSE" -> ExoPlayerManager.pause()
-            "ACTION_NEXT" -> ExoPlayerManager.playNext()
-            "ACTION_PREV" -> ExoPlayerManager.playPrevious()
-            "ACTION_STOP" -> {
+            ACTION_PLAY -> ExoPlayerManager.resume()
+            ACTION_PAUSE -> ExoPlayerManager.pause()
+            ACTION_NEXT -> ExoPlayerManager.playNext()
+            ACTION_PREV -> ExoPlayerManager.playPrevious()
+            ACTION_STOP -> {
                 ExoPlayerManager.pause()
-                stopForeground(true)
+                stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
                 return START_NOT_STICKY
             }
         }
 
-        showCustomNotification()
+        showPlayerNotification()
         return START_STICKY
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        Log.d("MusicPlayerService", "🛑 Servicio detenido")
-        stopForeground(true)
+        stopForeground(STOP_FOREGROUND_REMOVE)
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -70,11 +66,12 @@ class MusicPlayerService : Service() {
     private fun createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
-                "pulseplayer_channel",
+                CHANNEL_ID,
                 "PulsePlayer",
                 NotificationManager.IMPORTANCE_LOW
             ).apply {
-                description = "Control de reproducción de PulsePlayer"
+                description = "Controles de reproducción"
+                setShowBadge(false)
                 lockscreenVisibility = Notification.VISIBILITY_PUBLIC
             }
             val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -82,88 +79,75 @@ class MusicPlayerService : Service() {
         }
     }
 
-    private fun showCustomNotification() {
-        val player = ExoPlayerManager.getPlayer()
+    private fun showPlayerNotification() {
         val song = ExoPlayerManager.getCurrentSong() ?: return
-        val isPlaying = player?.isPlaying == true
+        val isPlaying = ExoPlayerManager.getPlayer()?.isPlaying == true
 
-        // Intents para los botones
-        val playPauseIntent = Intent(this, MusicPlayerService::class.java).apply {
-            action = if (isPlaying) "ACTION_PAUSE" else "ACTION_PLAY"
-        }
-        val prevIntent = Intent(this, MusicPlayerService::class.java).apply {
-            action = "ACTION_PREV"
-        }
-        val nextIntent = Intent(this, MusicPlayerService::class.java).apply {
-            action = "ACTION_NEXT"
-        }
-        val stopIntent = Intent(this, MusicPlayerService::class.java).apply {
-            action = "ACTION_STOP"
-        }
+        val openAppIntent = PendingIntent.getActivity(
+            this,
+            20,
+            Intent(this, MainActivity::class.java).apply { flags = Intent.FLAG_ACTIVITY_SINGLE_TOP },
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
 
-        // PendingIntents
-        val playPausePendingIntent = PendingIntent.getService(this, 0, playPauseIntent, PendingIntent.FLAG_IMMUTABLE)
-        val prevPendingIntent = PendingIntent.getService(this, 1, prevIntent, PendingIntent.FLAG_IMMUTABLE)
-        val nextPendingIntent = PendingIntent.getService(this, 2, nextIntent, PendingIntent.FLAG_IMMUTABLE)
-        val stopPendingIntent = PendingIntent.getService(this, 3, stopIntent, PendingIntent.FLAG_IMMUTABLE)
+        val prevIntent = actionIntent(ACTION_PREV, 1)
+        val playPauseIntent = actionIntent(if (isPlaying) ACTION_PAUSE else ACTION_PLAY, 2)
+        val nextIntent = actionIntent(ACTION_NEXT, 3)
+        val stopIntent = actionIntent(ACTION_STOP, 4)
 
-        // RemoteViews personalizados
-        val remoteViews = RemoteViews(packageName, R.layout.notification_music_player).apply {
-            setTextViewText(R.id.text_title, song.title.ifEmpty { "Título desconocido" })
-            setTextViewText(R.id.text_artist, song.artistName.ifEmpty { "Artista desconocido" })
+        val artwork = getBitmapFromUri(song.coverImage)
 
-            // Cargar portada desde URI
-            val bitmap = getBitmapFromUri(song.coverImage)
-            if (bitmap != null) {
-                setImageViewBitmap(R.id.image_cover, bitmap)
-            } else {
-                setImageViewResource(R.id.image_cover, R.drawable.ic_music_placeholder)
-            }
-
-            // Botón play/pause
-            setImageViewResource(
-                R.id.btn_play_pause,
-                if (isPlaying) R.drawable.pause2_icon else R.drawable.play2_icon
-            )
-            setOnClickPendingIntent(R.id.btn_play_pause, playPausePendingIntent)
-
-            // Botones anteriores/siguiente/cerrar
-            setImageViewResource(R.id.btn_prev, R.drawable.back2_icon)
-            setImageViewResource(R.id.btn_next, R.drawable.skip2_icon)
-            setImageViewResource(R.id.btn_close, R.drawable.stop_icon)
-
-            setOnClickPendingIntent(R.id.btn_prev, prevPendingIntent)
-            setOnClickPendingIntent(R.id.btn_next, nextPendingIntent)
-            setOnClickPendingIntent(R.id.btn_close, stopPendingIntent)
-        }
-
-        // Construcción de la notificación
-        val notification = NotificationCompat.Builder(this, "pulseplayer_channel")
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.logo_ico)
             .setColor(ContextCompat.getColor(this, R.color.pulse_blue))
-            .setStyle(NotificationCompat.DecoratedCustomViewStyle())
-            .setCustomContentView(remoteViews)
-            .setPriority(NotificationCompat.PRIORITY_LOW)
-            .setOngoing(true)
+            .setContentTitle(song.title.ifBlank { "Pulse Player" })
+            .setContentText(song.artistName.ifBlank { "Artista desconocido" })
+            .setLargeIcon(artwork)
+            .setContentIntent(openAppIntent)
+            .setDeleteIntent(stopIntent)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setOnlyAlertOnce(true)
+            .setOngoing(isPlaying)
+            .addAction(R.drawable.back2_icon, getString(R.string.previous), prevIntent)
+            .addAction(
+                if (isPlaying) R.drawable.pause2_icon else R.drawable.play2_icon,
+                if (isPlaying) getString(R.string.pause) else getString(R.string.play),
+                playPauseIntent
+            )
+            .addAction(R.drawable.skip2_icon, getString(R.string.next), nextIntent)
+            .setStyle(MediaStyle().setShowActionsInCompactView(0, 1, 2))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()
 
-        startForeground(1, notification)
+        startForeground(NOTIFICATION_ID, notification)
+    }
+
+    private fun actionIntent(action: String, requestCode: Int): PendingIntent {
+        return PendingIntent.getService(
+            this,
+            requestCode,
+            Intent(this, MusicPlayerService::class.java).setAction(action),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
     }
 
     private fun getBitmapFromUri(uriString: String?): Bitmap? {
         if (uriString.isNullOrEmpty()) return null
         return try {
             val uri = Uri.parse(uriString)
-            contentResolver.openInputStream(uri)?.use {
-                BitmapFactory.decodeStream(it)
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
+            contentResolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it) }
+        } catch (_: Exception) {
             null
         }
     }
 
-
-
+    companion object {
+        private const val CHANNEL_ID = "pulseplayer_channel"
+        private const val NOTIFICATION_ID = 1
+        private const val ACTION_PLAY = "ACTION_PLAY"
+        private const val ACTION_PAUSE = "ACTION_PAUSE"
+        private const val ACTION_NEXT = "ACTION_NEXT"
+        private const val ACTION_PREV = "ACTION_PREV"
+        private const val ACTION_STOP = "ACTION_STOP"
+    }
 }


### PR DESCRIPTION
### Motivation
- Transformar el mock HTML/CSS enviado a una interfaz moderna en Jetpack Compose y aplicar los colores/estética del logo al diseño de la app.
- Hacer que la sección "Álbumes" sea funcional y mejorar la experiencia de reproducción en segundo plano con notificaciones y controles multimedia.

### Description
- Reescribí la pantalla principal `MenuScreen` para reflejar el diseño: cabecera con branding, hero card "Música", grid de biblioteca, mini player estilizado y barra inferior (archivo `app/src/main/java/com/example/pulseplayer/views/menu.kt`).
- Añadí `AlbumsScreen.kt` y registré la ruta `Albums` en `NavController.kt`, agrupando canciones por álbum y permitiendo reproducir un álbum completo y navegar a `NowPlaying` (`app/src/main/java/com/example/pulseplayer/views/AlbumsScreen.kt`, `app/src/main/java/com/example/pulseplayer/NavController.kt`).
- Actualicé `MiniPlayerBar.kt` para un mini-player con portada, título/artista y botones prev/play/next que se sincronizan con `ExoPlayerManager` y adoptan la nueva estética (`app/src/main/java/com/example/pulseplayer/ui/components/MiniPlayerBar.kt`).
- Reimplementé `MusicPlayerService.kt` para construir una notificación multimedia moderna (acciones prev/play/pause/next, apertura de la app desde la notificación, canal configurado y cierre limpio) y ajusté `MainActivity.kt` para detener el servicio al volver al foreground (`app/src/main/java/com/example/pulseplayer/views/service/MusicPlayerService.kt`, `app/src/main/java/com/example/pulseplayer/MainActivity.kt`).

### Testing
- Intenté compilar el módulo con `./gradlew :app:compileDebugKotlin`, pero la ejecución falló al descargar el wrapper por restricciones de red/proxy (HTTP 403), por lo que no se pudo generar un build automático.
- Se realizaron comprobaciones locales no destructivas como `git status --short` y se confirmó que los cambios fueron añadidos y commiteados correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1cc7f998483259a7bb0b07a35864c)