### PR TITLE
Add Albums screen, UI refresh for MiniPlayer/NowPlaying, equalizer support and improved service notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/pulseplayer/MainActivity.kt
+++ b/app/src/main/java/com/example/pulseplayer/MainActivity.kt
@@ -49,8 +49,9 @@ class MainActivity : ComponentActivity() {
                     }
                 },
                 onAppForegrounded = {
+                    stopService(Intent(this, MusicPlayerService::class.java))
                     val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-                    manager.cancel(1) // Oculta la notificación al volver a la app
+                    manager.cancel(1)
                 }
             )
         )

--- a/app/src/main/java/com/example/pulseplayer/NavController.kt
+++ b/app/src/main/java/com/example/pulseplayer/NavController.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.example.pulseplayer.data.entity.Song
+import com.example.pulseplayer.views.AlbumsScreen
 import com.example.pulseplayer.views.MenuScreen
 import com.example.pulseplayer.views.MusicScreen
 import com.example.pulseplayer.views.favorite.FavoriteScreen
@@ -27,6 +28,9 @@ object Menu
 // MUSICA
 @Serializable
 object Music
+
+@Serializable
+object Albums
 
 @Serializable
 data class NowPlaying(val songId: Int, val songIds: List<Int> )
@@ -65,6 +69,9 @@ fun Navigation(songs: List<Song>){
         }
         composable<Music> {
             MusicScreen(navController = navController) // ✅ corregido
+        }
+        composable<Albums> {
+            AlbumsScreen(navController = navController)
         }
         composable<NowPlaying> { backStackEntry ->
             val args = backStackEntry.toRoute<NowPlaying>()

--- a/app/src/main/java/com/example/pulseplayer/ui/components/MiniPlayerBar.kt
+++ b/app/src/main/java/com/example/pulseplayer/ui/components/MiniPlayerBar.kt
@@ -1,6 +1,7 @@
 package com.example.pulseplayer.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -9,17 +10,18 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.outlined.FastForward
+import androidx.compose.material.icons.outlined.FastRewind
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -33,7 +35,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.navigation.NavController
@@ -47,7 +48,6 @@ fun MiniPlayerBar(navController: NavController, modifier: Modifier = Modifier) {
     val currentSong = remember { mutableStateOf(ExoPlayerManager.getCurrentSong()) }
     val isPlaying = remember { mutableStateOf(ExoPlayerManager.getPlayer()?.isPlaying == true) }
 
-    // Listener de cambios en reproducción
     DisposableEffect(Unit) {
         val player = ExoPlayerManager.getPlayer()
         val listener = object : Player.Listener {
@@ -61,70 +61,53 @@ fun MiniPlayerBar(navController: NavController, modifier: Modifier = Modifier) {
             }
         }
         player?.addListener(listener)
-
-        onDispose {
-            player?.removeListener(listener)
-        }
+        onDispose { player?.removeListener(listener) }
     }
-
 
     val song = currentSong.value ?: return
 
-    Box(
+    Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(72.dp)
-            .background(
-                MaterialTheme.colorScheme.primary
-            )
-            .clickable {
-                navController.navigate(
-                    NowPlaying(song.idSong, listOf(song.idSong))
-                )
-            }
-            .padding(start = 12.dp, top = 8.dp, end = 12.dp, bottom = 8.dp),
-        contentAlignment = Alignment.CenterStart
+            .height(74.dp)
+            .clip(RoundedCornerShape(18.dp))
+            .background(Brush.horizontalGradient(listOf(Color(0xFF171A2C), Color(0xFF121527))))
+            .border(1.dp, Color.White.copy(alpha = 0.08f), RoundedCornerShape(18.dp))
+            .clickable { navController.navigate(NowPlaying(song.idSong, listOf(song.idSong))) }
+            .padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            AsyncImage(
-                model = song.coverImage?.ifEmpty { R.drawable.ic_music_placeholder },
-                contentDescription = null,
-                modifier = Modifier
-                    .size(48.dp)
-                    .clip(RoundedCornerShape(8.dp)),
-                contentScale = ContentScale.Crop
-            )
+        AsyncImage(
+            model = song.coverImage?.ifEmpty { R.drawable.ic_music_placeholder },
+            contentDescription = null,
+            modifier = Modifier.size(48.dp).clip(RoundedCornerShape(12.dp)),
+            contentScale = ContentScale.Crop
+        )
 
-            Spacer(modifier = Modifier.width(12.dp))
+        Spacer(Modifier.width(10.dp))
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.Center) {
+            Text(song.title, color = Color.White, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Text(song.artistName, color = Color.White.copy(alpha = 0.6f), maxLines = 1, overflow = TextOverflow.Ellipsis)
+        }
 
-            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.Center) {
-                Text(
-                    song.title,
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-//                    modifier = Modifier.offset(y = (3).dp)
-                )
-                Text(
-                    text = song.artistName,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-//                    modifier = Modifier.offset(y = (-3).dp)
-                )
-            }
-
+        IconButton(onClick = { ExoPlayerManager.playPrevious() }) {
+            Icon(Icons.Outlined.FastRewind, contentDescription = null, tint = Color.White.copy(alpha = 0.7f))
+        }
+        Box(
+            modifier = Modifier
+                .size(42.dp)
+                .clip(CircleShape)
+                .background(Brush.linearGradient(listOf(Color(0xFF7C3AED), Color(0xFF4F46E5)))),
+            contentAlignment = Alignment.Center
+        ) {
             IconButton(onClick = {
                 if (isPlaying.value) ExoPlayerManager.pause() else ExoPlayerManager.resume()
             }) {
-                Icon(
-                    imageVector = if (isPlaying.value) Icons.Default.Pause else Icons.Default.PlayArrow,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimary,
-                )
+                Icon(if (isPlaying.value) Icons.Rounded.Pause else Icons.Rounded.PlayArrow, contentDescription = null, tint = Color.White)
             }
+        }
+        IconButton(onClick = { ExoPlayerManager.playNext() }) {
+            Icon(Icons.Outlined.FastForward, contentDescription = null, tint = Color.White.copy(alpha = 0.7f))
         }
     }
 }

--- a/app/src/main/java/com/example/pulseplayer/views/AlbumsScreen.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/AlbumsScreen.kt
@@ -1,0 +1,107 @@
+package com.example.pulseplayer.views
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Album
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.pulseplayer.NowPlaying
+import com.example.pulseplayer.ui.components.MiniPlayerBar
+import com.example.pulseplayer.views.viewmodel.PlayerViewModel
+import com.example.pulseplayer.views.viewmodel.SongViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AlbumsScreen(navController: NavController) {
+    val songViewModel: SongViewModel = viewModel()
+    val playerViewModel: PlayerViewModel = viewModel()
+    val songs by songViewModel.allSongs.collectAsState()
+
+    val albums = songs
+        .groupBy { it.album?.trim().takeUnless { it.isNullOrEmpty() } ?: "Sin álbum" }
+        .map { (album, albumSongs) -> album to albumSongs.sortedBy { it.trackNumber?.toIntOrNull() ?: Int.MAX_VALUE } }
+        .sortedBy { it.first.lowercase() }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Álbumes", color = Color.White) },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF090B1A))
+            )
+        },
+        bottomBar = {
+            MiniPlayerBar(navController = navController, modifier = Modifier.fillMaxWidth())
+        },
+        containerColor = Color(0xFF060911)
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color(0xFF060911))
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            items(albums) { (album, albumSongs) ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            if (albumSongs.isNotEmpty()) {
+                                playerViewModel.playPlaylist(albumSongs, 0)
+                                navController.navigate(NowPlaying(albumSongs.first().idSong, albumSongs.map { it.idSong }))
+                            }
+                        },
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color.Transparent)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(Brush.horizontalGradient(listOf(Color(0xFF172554), Color(0xFF1E1B4B))))
+                            .padding(14.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(Icons.Outlined.Album, contentDescription = null, tint = Color(0xFFA78BFA))
+                        Column(modifier = Modifier.padding(start = 12.dp).weight(1f)) {
+                            Text(album, color = Color.White, style = MaterialTheme.typography.titleMedium)
+                            Text("${albumSongs.size} canciones", color = Color.White.copy(alpha = 0.65f))
+                        }
+                        Text(
+                            text = albumSongs.firstOrNull()?.artistName ?: "",
+                            color = Color.White.copy(alpha = 0.55f),
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/pulseplayer/views/MusicScreen.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/MusicScreen.kt
@@ -1,87 +1,97 @@
 package com.example.pulseplayer.views
 
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.MusicNote
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-import coil.compose.rememberAsyncImagePainter
+import coil.compose.AsyncImage
 import com.example.pulseplayer.Music
 import com.example.pulseplayer.NowPlaying
 import com.example.pulseplayer.R
-import com.example.pulseplayer.data.PulsePlayerDatabase
-import com.example.pulseplayer.data.entity.Song
 import com.example.pulseplayer.ui.components.MiniPlayerBar
 import com.example.pulseplayer.views.viewmodel.PlayerViewModel
 import com.example.pulseplayer.views.viewmodel.SongViewModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.flow.first
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MusicScreen(navController: NavController) {
-    val context = LocalContext.current
-    val scope = rememberCoroutineScope()
     val songViewModel: SongViewModel = viewModel()
     val songs by songViewModel.allSongs.collectAsState()
     val playerViewModel: PlayerViewModel = viewModel()
-    var selectedSongId by remember { mutableStateOf<Int?>(null) }
-
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = stringResource(R.string.title_music),
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
-                },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary),
-            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color(0xFF090B1A))
+                    .statusBarsPadding()
+                    .height(56.dp)
+                    .padding(horizontal = 16.dp),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Text("Música", color = Color.White, style = MaterialTheme.typography.titleLarge)
+            }
         },
         bottomBar = {
             MiniPlayerBar(
                 navController = navController,
-                modifier = Modifier.fillMaxWidth().wrapContentHeight().navigationBarsPadding(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .navigationBarsPadding()
             )
         },
-        containerColor = MaterialTheme.colorScheme.background,
+        containerColor = Color(0xFF060911)
     ) { padding ->
         LazyColumn(
             contentPadding = padding,
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
-                .padding(WindowInsets.systemBars.asPaddingValues())
+                .background(Color(0xFF060911))
+                .padding(horizontal = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             items(songs) { song ->
                 SongCardItem(
                     song = song,
                     isSelected = playerViewModel.currentSong.value?.idSong == song.idSong,
                     onClick = {
-                        val allSongIds = songs.map { it.idSong } //navegar a la pantalla de reproducción
+                        val allSongIds = songs.map { it.idSong }
                         val startIndex = songs.indexOfFirst { it.idSong == song.idSong }
                         playerViewModel.playPlaylist(songs, startIndex)
                         navController.navigate(NowPlaying(song.idSong, allSongIds)) {
@@ -96,60 +106,45 @@ fun MusicScreen(navController: NavController) {
 }
 
 @Composable
-fun SongCardItem(song: Song, isSelected: Boolean, onClick: () -> Unit) {
+fun SongCardItem(song: com.example.pulseplayer.data.entity.Song, isSelected: Boolean, onClick: () -> Unit) {
     val borderColor by animateColorAsState(
-        targetValue = if (isSelected) Color(0xFF9C27B0) else Color.Transparent,
+        targetValue = if (isSelected) Color(0xFF8B5CF6) else Color.Transparent,
         label = "borderColor"
     )
 
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 6.dp)
-            .border(2.dp, borderColor, shape = RoundedCornerShape(16.dp))
+            .border(1.5.dp, borderColor, shape = RoundedCornerShape(16.dp))
             .clickable { onClick() },
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
         shape = RoundedCornerShape(16.dp)
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .background(Brush.horizontalGradient(listOf(Color(0xFF131D37), Color(0xFF0B1328))))
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            val painter = rememberAsyncImagePainter(
-                model = song.coverImage?.ifEmpty { R.drawable.ic_music_placeholder }
-            )
-
-            Image(
-                painter = painter,
+            AsyncImage(
+                model = song.coverImage?.ifEmpty { R.drawable.ic_music_placeholder },
                 contentDescription = "Cover",
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
-                    .size(56.dp)
-                    .clip(CircleShape)
+                    .size(54.dp)
+                    .clip(RoundedCornerShape(12.dp))
             )
 
             Spacer(modifier = Modifier.width(12.dp))
 
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = song.title,
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-                Text(
-                    text = song.artistName,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                Text(text = song.title, style = MaterialTheme.typography.titleSmall, color = Color.White)
+                Text(text = song.artistName, style = MaterialTheme.typography.bodySmall, color = Color.White.copy(alpha = 0.6f))
             }
 
-            Text(
-                text = song.formattedDuration,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
+            Icon(Icons.Outlined.MusicNote, contentDescription = null, tint = Color(0xFFA78BFA), modifier = Modifier.padding(end = 8.dp))
+            Text(text = song.formattedDuration, style = MaterialTheme.typography.bodySmall, color = Color.White.copy(alpha = 0.75f))
         }
     }
 }

--- a/app/src/main/java/com/example/pulseplayer/views/favorite/FavoriteScreen.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/favorite/FavoriteScreen.kt
@@ -51,10 +51,10 @@ fun FavoriteScreen(
                     Text(
                         text = stringResource(R.string.favorites_screen_title),
                         style = MaterialTheme.typography.headlineSmall,
-                        color = MaterialTheme.colorScheme.onPrimary,
+                        color = Color.White,
                     )
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary)
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF090B1A))
             )
         },
         bottomBar = {
@@ -63,13 +63,13 @@ fun FavoriteScreen(
                 modifier = Modifier.fillMaxWidth().wrapContentHeight().navigationBarsPadding(),
             )
         },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = Color(0xFF060911)
     ) { padding ->
         LazyColumn(
             contentPadding = padding,
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
+                .background(Color(0xFF060911))
         ) {
             if (favorites.isEmpty()) {
                 item {

--- a/app/src/main/java/com/example/pulseplayer/views/menu.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/menu.kt
@@ -1,257 +1,285 @@
 package com.example.pulseplayer.views
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.outlined.AccessTime
+import androidx.compose.material.icons.outlined.Album
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.LibraryMusic
+import androidx.compose.material.icons.outlined.QueueMusic
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.rounded.GraphicEq
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.example.pulseplayer.Albums
 import com.example.pulseplayer.FavoriteScreen
 import com.example.pulseplayer.Music
 import com.example.pulseplayer.PlaybackHistoryScreen
 import com.example.pulseplayer.PlaylistScreen
-import com.example.pulseplayer.R
-import com.example.pulseplayer.isLandscape
 import com.example.pulseplayer.ui.components.MiniPlayerBar
-import org.burnoutcrew.reorderable.ReorderableItem
-import org.burnoutcrew.reorderable.detectReorderAfterLongPress
-import org.burnoutcrew.reorderable.rememberReorderableLazyGridState
-import org.burnoutcrew.reorderable.reorderable
+import com.example.pulseplayer.views.viewmodel.PlaylistViewModel
+import com.example.pulseplayer.views.viewmodel.SongViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MenuScreen(navController: NavController) {
-    //orientacion de la pantalla
-    val landscape = isLandscape()
+    val songViewModel: SongViewModel = viewModel()
+    val playlistViewModel: PlaylistViewModel = viewModel()
+    val songs by songViewModel.allSongs.collectAsState()
+    val playlists by playlistViewModel.playlists.collectAsState()
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = stringResource(R.string.app_name),
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primary
-                )
+    val albumCount = songs.map { it.album?.trim().orEmpty() }
+        .filter { it.isNotEmpty() }
+        .distinct()
+        .size
+
+    val categories = listOf(
+        LibraryCategory("Álbumes", "$albumCount álbumes", Icons.Outlined.Album, Color(0xFF8B5CF6)) { navController.navigate(Albums) },
+        LibraryCategory("Listas", "${playlists.size} listas", Icons.Outlined.QueueMusic, Color(0xFF60A5FA)) { navController.navigate(PlaylistScreen) },
+        LibraryCategory("Historial", "Recientes", Icons.Outlined.AccessTime, Color(0xFF34D399)) { navController.navigate(PlaybackHistoryScreen) },
+        LibraryCategory("Favoritos", "${songs.count { it.isFavorite }} canciones", Icons.Outlined.FavoriteBorder, Color(0xFFFB7185)) { navController.navigate(FavoriteScreen) }
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Brush.verticalGradient(listOf(Color(0xFF090B1A), Color(0xFF05060D))))
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(horizontal = 20.dp)
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            HomeHeader()
+            HeroMusicCard(onClick = { navController.navigate(Music) })
+
+            Text(
+                text = "BIBLIOTECA",
+                color = Color.White.copy(alpha = 0.4f),
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 13.sp,
+                modifier = Modifier.padding(top = 18.dp, bottom = 10.dp)
             )
-        },
-        bottomBar = {
+
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                userScrollEnabled = false,
+                modifier = Modifier.height(270.dp)
+            ) {
+                items(categories.size) { index ->
+                    CategoryCard(categories[index])
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
             MiniPlayerBar(
                 navController = navController,
-                modifier = Modifier.fillMaxWidth().wrapContentHeight().navigationBarsPadding(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp)
             )
-        },
-        containerColor = MaterialTheme.colorScheme.background,
-    ) { innerPadding ->
-        val modifier = Modifier.fillMaxSize().padding(innerPadding).padding(20.dp)
 
-        if (landscape) {
-            Row(
-                modifier = modifier,
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                //musiccard a la izquierda
-                Column(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight(),
-                    verticalArrangement = Arrangement.Top
-                ) {
-                    MusicCard(
-                        title = stringResource(R.string.title_music),
-                        icon = Icons.Default.MusicNote,
-                        colors = listOf(Color(0xFFFF416C), Color(0xFFFF4B2B)),
-                        onClick = { navController.navigate(Music) },
-                        modifier = Modifier
-                            .height(200.dp)
-                            .fillMaxWidth()
-                    )
-                }
-                //categorias ordenables a la derecha
-                Column(
-                    modifier = Modifier
-                        .weight(2f)
-                        .fillMaxHeight()
-                ) {
-                    ReorderableCategorySection(navController = navController)
-                }
-            }
-        } else {
-            Column(
-                modifier = modifier,
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                MusicCard(
-                    title = stringResource(R.string.title_music),
-                    icon = Icons.Default.MusicNote,
-                    colors = listOf(Color(0xFFFF416C), Color(0xFFFF4B2B)),
-                    onClick = { navController.navigate(Music) }
-                )
-
-                ReorderableCategorySection(navController = navController)
-
-            }
+            BottomNavStrip(
+                onHomeClick = {},
+                onSearchClick = { navController.navigate(Music) },
+                onLibraryClick = { navController.navigate(Albums) },
+                modifier = Modifier.padding(top = 16.dp)
+            )
         }
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 4.dp)
+                .width(132.dp)
+                .height(4.dp)
+                .clip(CircleShape)
+                .background(Color.White.copy(alpha = 0.2f))
+        )
     }
 }
 
 @Composable
-fun MusicCard(
-    title: String,
-    icon: ImageVector,
-    colors: List<Color>,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-        .fillMaxWidth()
-        .height(100.dp)) {
-    Box(
-        modifier = modifier
-            .background(
-                brush = Brush.horizontalGradient(colors),
-                shape = RoundedCornerShape(16.dp)
-            )
-            .clickable(onClick = onClick),
-        contentAlignment = Alignment.Center
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = Color.White,
-                modifier = Modifier.size(36.dp)
-            )
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onPrimary,
-            )
-        }
-    }
-}
-
-@Composable
-fun CategoryCard(
-    title: String,
-    iconId: Int,
-    colors: List<Color>,
-    modifier: Modifier,
-    onClick: () -> Unit
-){
-    Box(
-        modifier = modifier
-            .height(100.dp)
-            .background(
-                brush = Brush.horizontalGradient(colors),
-                shape = RoundedCornerShape(16.dp)
-            )
-            .clickable { onClick() },  // ✅ ejecuta el onClick real
-        contentAlignment = Alignment.Center
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Icon(
-                painter = painterResource(id = iconId),
-                contentDescription = null,
-                tint = Color.White,
-                modifier = Modifier.size(36.dp)
-            )
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.onPrimary,
-            )
-        }
-    }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-fun ReorderableCategorySection(navController: NavController) {
-    val items = remember { mutableStateListOf("Álbumes", "Listas", "Historial", "Favorito") }
-    val landscape = isLandscape()
-
-    val state = rememberReorderableLazyGridState(onMove = { from, to ->
-        val item = items.removeAt(from.index)
-        items.add(to.index, item)
-    })
-
-    val columns = if (landscape) 3 else 2 //si es horizontal 3 columnas, si es vertical 2
-
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(columns),
-        state = state.gridState,
+private fun HomeHeader() {
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(if (landscape) 200.dp else 240.dp)
-            .reorderable(state)
-            .detectReorderAfterLongPress(state),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        contentPadding = PaddingValues(bottom = 8.dp)
+            .padding(top = 8.dp, bottom = 20.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        items(items.size, { items[it] }) { index ->
-            val title = items[index]
-            ReorderableItem(state, key = title) {
-                val cardModifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(if (landscape) 1.5f else 2f)
-                    .animateItemPlacement()
-
-                CategoryCardDynamic(title = title, modifier = cardModifier, navController = navController)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(Brush.linearGradient(listOf(Color(0xFF7C3AED), Color(0xFF4F46E5)))),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(Icons.Rounded.GraphicEq, contentDescription = null, tint = Color.White)
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .size(10.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFF4ADE80))
+                        .border(2.dp, Color(0xFF090B1A), CircleShape)
+                )
             }
+            Spacer(Modifier.width(12.dp))
+            Column {
+                Text("Pulse Player", color = Color.White, fontWeight = FontWeight.Bold, fontSize = 18.sp)
+                Text("Reproductor Local", color = Color.White.copy(alpha = 0.45f), fontSize = 13.sp)
+            }
+        }
+
+        IconButton(
+            onClick = {},
+            modifier = Modifier
+                .size(42.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(Color.White.copy(alpha = 0.06f))
+                .border(1.dp, Color.White.copy(alpha = 0.08f), RoundedCornerShape(12.dp))
+        ) {
+            Icon(Icons.Outlined.Settings, contentDescription = null, tint = Color.White.copy(alpha = 0.7f))
         }
     }
 }
 
 @Composable
-fun CategoryCardDynamic(
-    title: String,
-    modifier: Modifier = Modifier,
-    navController: NavController? = null
-) {
-    val (iconId, colors) = when (title) {
-        "Álbumes" -> R.drawable.ic_album to listOf(Color(0xFF2193b0), Color(0xFF6dd5ed))
-        "Listas" -> R.drawable.ic_category to listOf(Color(0xFF56ab2f), Color(0xFFA8E063))
-        "Historial" -> R.drawable.ic_history to listOf(Color(0xFF7F00FF), Color(0xFFE100FF))
-        "Favorito" -> R.drawable.ic_favorite to listOf(Color(0xFFff6a00), Color(0xFFee0979))
-        else -> R.drawable.ic_album to listOf(Color.Gray, Color.LightGray)
-    }
-
-    val onClick: () -> Unit = {
-        when (title) {
-            "Listas" -> navController?.navigate(PlaylistScreen)
-            "Historial" -> navController?.navigate(PlaybackHistoryScreen)
-            "Favorito" -> navController?.navigate(FavoriteScreen) // 🔸 Aquí se agregó
-            else -> {}
+private fun HeroMusicCard(onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(210.dp)
+            .clip(RoundedCornerShape(26.dp))
+            .background(Brush.linearGradient(listOf(Color(0xFF5B21B6), Color(0xFF1E3A8A), Color(0xFF0F172A))))
+            .clickable(onClick = onClick)
+            .padding(24.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Box(
+                modifier = Modifier
+                    .size(66.dp)
+                    .clip(RoundedCornerShape(20.dp))
+                    .background(Color.White.copy(alpha = 0.12f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(Icons.Rounded.MusicNote, contentDescription = null, tint = Color.White, modifier = Modifier.size(34.dp))
+            }
+            Text("Música", color = Color.White, fontSize = 24.sp, fontWeight = FontWeight.Bold, modifier = Modifier.padding(top = 10.dp))
+            Text("Explorar biblioteca", color = Color.White.copy(alpha = 0.6f), fontSize = 15.sp)
         }
     }
+}
 
-    CategoryCard(
-        title = title,
-        iconId = iconId,
-        colors = colors,
-        modifier = modifier,
-        onClick = onClick
-    )
+data class LibraryCategory(
+    val title: String,
+    val subtitle: String,
+    val icon: ImageVector,
+    val color: Color,
+    val onClick: () -> Unit
+)
+
+@Composable
+private fun CategoryCard(item: LibraryCategory) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(Brush.linearGradient(listOf(Color(0xFF13203C), Color(0xFF0A132B))))
+            .border(1.dp, Color.White.copy(alpha = 0.06f), RoundedCornerShape(18.dp))
+            .clickable(onClick = item.onClick)
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(item.color.copy(alpha = 0.16f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(item.icon, contentDescription = null, tint = item.color)
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        Text(item.title, color = Color.White, fontWeight = FontWeight.SemiBold)
+        Text(item.subtitle, color = Color.White.copy(alpha = 0.45f), fontSize = 13.sp)
+    }
+}
+
+@Composable
+private fun BottomNavStrip(
+    onHomeClick: () -> Unit,
+    onSearchClick: () -> Unit,
+    onLibraryClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp),
+        horizontalArrangement = Arrangement.SpaceAround,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        BottomNavItem("Inicio", Icons.Outlined.Home, true, onHomeClick)
+        BottomNavItem("Buscar", Icons.Outlined.Search, false, onSearchClick)
+        BottomNavItem("Biblioteca", Icons.Outlined.LibraryMusic, false, onLibraryClick)
+    }
+}
+
+@Composable
+private fun BottomNavItem(label: String, icon: ImageVector, selected: Boolean, onClick: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.clickable(onClick = onClick).padding(4.dp)
+    ) {
+        Icon(icon, contentDescription = label, tint = if (selected) Color(0xFF8B5CF6) else Color.White.copy(alpha = 0.38f))
+        Text(
+            text = label,
+            color = if (selected) Color(0xFF8B5CF6) else Color.White.copy(alpha = 0.38f),
+            fontSize = 12.sp,
+            textAlign = TextAlign.Center
+        )
+    }
 }

--- a/app/src/main/java/com/example/pulseplayer/views/playbackhistory/PlaybackHistoryScreen.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/playbackhistory/PlaybackHistoryScreen.kt
@@ -70,14 +70,14 @@ fun PlaybackHistoryScreen(navController: NavController, playerViewModel: PlayerV
                 title = { Text(
                     "Historial",
                     style = MaterialTheme.typography.headlineSmall,
-                    color = MaterialTheme.colorScheme.onPrimary,
+                    color = Color.White,
                     ) },
                 actions = {
                     IconButton(onClick = { showConfirmDialog = true }) {
-                        Icon(Icons.Default.Delete, contentDescription = "Eliminar historial", tint = MaterialTheme.colorScheme.onPrimary)
+                        Icon(Icons.Default.Delete, contentDescription = "Eliminar historial", tint = Color.White)
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary),
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF090B1A)),
             )
         },
         bottomBar = {
@@ -86,7 +86,7 @@ fun PlaybackHistoryScreen(navController: NavController, playerViewModel: PlayerV
                 modifier = Modifier.fillMaxWidth().wrapContentHeight().navigationBarsPadding(),
             )
         },
-        containerColor = MaterialTheme.colorScheme.background,
+        containerColor = Color(0xFF060911),
     ) { padding ->
         LazyColumn(
             modifier = Modifier

--- a/app/src/main/java/com/example/pulseplayer/views/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/player/NowPlayingScreen.kt
@@ -1,24 +1,52 @@
 package com.example.pulseplayer.views.player
 
-import android.widget.Space
+import android.media.audiofx.Equalizer
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Equalizer
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -26,406 +54,248 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.media3.exoplayer.ExoPlayer
-import androidx.navigation.NavController
 import coil.compose.rememberAsyncImagePainter
 import com.example.pulseplayer.R
 import com.example.pulseplayer.data.PulsePlayerDatabase
 import com.example.pulseplayer.data.entity.Song
-import com.example.pulseplayer.isLandscape
 import com.example.pulseplayer.views.viewmodel.PlayerViewModel
 import kotlinx.coroutines.delay
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun NowPlayingScreen(navController: NavController, songId: Int, songIds: List<Int>, viewModel: PlayerViewModel = viewModel()) {
+fun NowPlayingScreen(
+    navController: androidx.navigation.NavController,
+    songId: Int,
+    songIds: List<Int>,
+    viewModel: PlayerViewModel = viewModel()
+) {
     val context = LocalContext.current
-    val currentSong by viewModel.currentSong // Observa la canción actual del ViewModel
+    val currentSong by viewModel.currentSong
+    val isPlaying by viewModel.isPlaying
+    val isFavorite by viewModel.isCurrentFavorite
+    val exoPlayer = viewModel.getPlayer()
 
-    val exoPlayer = viewModel.getPlayer() // Obtiene la instancia del reproductor de ExoPlayerManager
     var currentPosition by remember { mutableStateOf(0L) }
-    var duration by remember { mutableStateOf(0L) }
-
-    // Estado para habilitar/deshabilitar los botones de navegación
+    var duration by remember { mutableStateOf(1L) }
     var canPlayNext by remember { mutableStateOf(false) }
     var canPlayPrevious by remember { mutableStateOf(false) }
+    var showEqDialog by remember { mutableStateOf(false) }
 
-    // Estados visuales (solo estético)
-    var isShuffleEnabled by remember { mutableStateOf(false) }
-    var isRepeatEnabled by remember { mutableStateOf(false) }
-    val isFavorite by viewModel.isCurrentFavorite
-
-    //orientacion de la pantalla
-    val landscape = isLandscape()
-
-    LaunchedEffect(currentSong?.idSong) {
-        viewModel.checkIfCurrentSongIsFavorite()
+    val equalizer = remember { PlayerEqualizer { viewModel.getPlayer() } }
+    DisposableEffect(Unit) {
+        onDispose { equalizer.release() }
     }
 
-    // Actualiza el progreso de la reproducción y la duración
+    LaunchedEffect(currentSong?.idSong) { viewModel.checkIfCurrentSongIsFavorite() }
+
+    LaunchedEffect(songId, songIds) {
+        if (viewModel.currentSong.value?.idSong != songId) {
+            val dao = PulsePlayerDatabase.getDatabase(context).songDao()
+            val songList = songIds.mapNotNull { dao.getById(it) }
+            val startIndex = songList.indexOfFirst { it.idSong == songId }
+            if (startIndex != -1) viewModel.playPlaylist(songList, startIndex)
+        }
+    }
+
     LaunchedEffect(exoPlayer) {
-        // Ver que el exoPlayer no sea nulo y esté listo para obtener la posición/duración
         exoPlayer?.let { player ->
             while (true) {
                 currentPosition = player.currentPosition
-                // Asegura que la duración no sea cero para evitar divisiones por cero en el Slider
-                duration = player.duration.takeIf { d -> d > 0 } ?: 1L
-
-                // Actualiza el estado de los botones
+                duration = player.duration.takeIf { it > 0 } ?: 1L
                 canPlayNext = player.hasNextMediaItem()
                 canPlayPrevious = player.hasPreviousMediaItem()
-
-                delay(500) // Actualiza cada 500ms
+                delay(300)
             }
         }
     }
 
-    // Carga la canción o playlist cuando la pantalla se lanza o los IDs cambian
-    LaunchedEffect(songId, songIds) {
-        // Solo carga la playlist si la canción actual del ViewModel no coincide con la solicitada,
-        // o si no hay ninguna canción reproduciéndose actualmente.
-        // Esto evita recargar innecesariamente la misma canción/playlist.
-        if (viewModel.currentSong.value?.idSong != songId) {
-            val dao = PulsePlayerDatabase.getDatabase(context).songDao()
-            // Mapea los IDs a objetos Song, filtrando cualquier resultado nulo
-            val songList = songIds.mapNotNull { dao.getById(it) }
-
-            val startIndex = songList.indexOfFirst { it.idSong == songId }
-
-            if (startIndex != -1) {
-                // Llama a playPlaylist del ViewModel, que a su vez usa el ExoPlayerManager
-                // para reemplazar completamente la cola de reproducción.
-                viewModel.playPlaylist(songList, startIndex)
-            }
-        }
-    }
-
-    // Muestra un indicador de carga si no hay ninguna canción cargada
     if (currentSong == null) {
         Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background),
+            modifier = Modifier.fillMaxSize().background(Color(0xFF060911)),
             contentAlignment = Alignment.Center
-        ) {
-            CircularProgressIndicator(color = MaterialTheme.colorScheme.onSurface)
-        }
+        ) { CircularProgressIndicator(color = Color.White) }
         return
     }
 
-    val isPlaying by viewModel.isPlaying // Observa el estado de reproducción del ViewModel
-
     Scaffold(
-        containerColor = MaterialTheme.colorScheme.background,
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = stringResource(R.string.playing_music),
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primary
-                ),
-                actions = {
-                    IconButton(onClick = {
-                        viewModel.toggleFavoriteStatus()
-                    }) {
-                        Icon(
-                            imageVector = Icons.Default.Favorite,
-                            contentDescription = "Favorito",
-                            tint = if (isFavorite)
-                                MaterialTheme.colorScheme.error
-                            else
-                                MaterialTheme.colorScheme.onPrimary
-                        )
-                    }
-
-                }
-            )
-        }
-    ) { padding ->
-        //si el modo landscape esta activado toma este diseño
-        if (landscape) {
+        containerColor = Color(0xFF060911),
+        bottomBar = {
             Row(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-                    .padding(horizontal = 16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceAround,
-            ) {
-                //imagen a la izquierda
-                Card(
-                    modifier = Modifier
-                        .weight(1f)
-                        .aspectRatio(1f),
-                    shape = RoundedCornerShape(24.dp)
-                ) {
-                    val painter = rememberAsyncImagePainter(
-                        model = if (currentSong!!.coverImage?.isEmpty() == true)
-                            R.drawable.ic_music_placeholder
-                        else currentSong!!.coverImage
-                    )
-                    Image(
-                        painter = painter,
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                }
-
-                Spacer(modifier = Modifier.width(24.dp))
-
-                //controles a la derecha
-                Column(
-                    modifier = Modifier.weight(2f),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    SongDetails(currentSong!!)
-                    Spacer(modifier = Modifier.height(16.dp))
-                    ProgressSlider(currentPosition, duration, exoPlayer)
-                    Spacer(modifier = Modifier.height(16.dp))
-                    PlaybackControls(isPlaying, canPlayPrevious, canPlayNext, viewModel)
-                }
-            }
-        } else {
-            //sino ocupar el diseño vertical normal
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-                    .padding(horizontal = 24.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Spacer(modifier = Modifier.height(40.dp))
-
-                // Imagen contenida en Card
-                Card(
-                    modifier = Modifier
-                        .size(300.dp),
-                    shape = RoundedCornerShape(24.dp)
-                ) {
-                    val painter = rememberAsyncImagePainter(
-                        model = if (currentSong!!.coverImage?.isEmpty() == true) R.drawable.ic_music_placeholder else currentSong!!.coverImage
-                    )
-                    Image(
-                        painter = painter,
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier.fillMaxSize()
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(24.dp))
-                SongDetails(currentSong!!)
-                Spacer(modifier = Modifier.height(24.dp))
-                ProgressSlider(currentPosition, duration, exoPlayer)
-                Spacer(modifier = Modifier.height(24.dp))
-                PlaybackControls(isPlaying, canPlayPrevious, canPlayNext, viewModel)
-            }
-        }
-    }
-}
-
-//componente de controles de reproduccion
-@Composable
-fun PlaybackControls(isPlaying: Boolean, canPlayPrevious: Boolean, canPlayNext: Boolean, viewModel: PlayerViewModel) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceEvenly,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        val isShuffleEnabled by viewModel.isShuffleEnabled
-        val isRepeatEnabled by viewModel.isRepeatEnabled
-
-        IconButton(onClick = { viewModel.toggleShuffleMode() }) {
-            Icon(
-                imageVector = Icons.Default.Shuffle,
-                contentDescription = "Aleatorio",
-                tint = if (isShuffleEnabled) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.size(28.dp),
-            )
-        }
-
-        IconButton(
-            onClick = { viewModel.playPrevious() },
-            enabled = canPlayPrevious
-        ) {
-            Icon(Icons.Default.SkipPrevious, contentDescription = "Anterior", tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.size(36.dp))
-        }
-
-        IconButton(onClick = {
-            if (isPlaying) viewModel.pause() else viewModel.resume()
-        }) {
-            Icon(
-                imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                contentDescription = "Play/Pause",
-                tint = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.size(64.dp)
-            )
-        }
-
-        IconButton(
-            onClick = { viewModel.playNext() },
-            enabled = canPlayNext
-        ) {
-            Icon(Icons.Default.SkipNext, contentDescription = "Siguiente", tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.size(36.dp))
-        }
-
-        IconButton(onClick = { viewModel.toggleRepeatMode() }) {
-            Icon(
-                imageVector = Icons.Default.Repeat,
-                contentDescription = "Repetir",
-                tint = if (isRepeatEnabled) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.size(28.dp)
-            )
-        }
-    }
-}
-
-//componente de barra de progreso
-@Composable
-fun ProgressSlider(currentPosition: Long, duration: Long, exoPlayer: ExoPlayer?) {
-    Column(modifier = Modifier.fillMaxWidth()) {
-        CustomThinSlider(
-            value = currentPosition.toFloat(),
-            onValueChange = { exoPlayer?.seekTo(it.toLong()) },
-            valueRange = 0f..duration.toFloat()
-        )
-
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 4.dp),
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Text(
-                text = formatDuration(currentPosition),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-
-            Text(
-                text = formatDuration(duration),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-        }
-    }
-}
-
-//componente de detalles de la cancion
-@Composable
-fun SongDetails(song: Song) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(28.dp)
-                .horizontalScroll(rememberScrollState())
-        ) {
-            Text(
-                text = song.title,
-                style = MaterialTheme.typography.headlineSmall,
-                color = MaterialTheme.colorScheme.onBackground,
-                maxLines = 1,
-            )
-        }
-
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(20.dp)
-                .horizontalScroll(rememberScrollState())
-        ) {
-            Text(
-                text = song.artistName,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-            )
-        }
-    }
-}
-
-// Barra de Progreso Delgada
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun CustomThinSlider(
-    value: Float,
-    onValueChange: (Float) -> Unit,
-    valueRange: ClosedFloatingPointRange<Float>,
-    modifier: Modifier = Modifier
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-
-    Slider(
-        value = value,
-        onValueChange = onValueChange,
-        valueRange = valueRange,
-        interactionSource = interactionSource,
-        steps = 0,
-        modifier = modifier
-            .fillMaxWidth()
-            .height(24.dp), // Altura total del slider (incluyendo thumb)
-
-        // 🎯 THUMB PERSONALIZADO (bolita)
-        thumb = {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier.size(24.dp) // Espacio reservado para el thumb
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(12.dp) // Tamaño visible de la bolita
-                        .background(MaterialTheme.colorScheme.error, shape = CircleShape) // 🎨 COLOR DEL THUMB (círculo)
-                )
-            }
-        },
-
-        // 🎯 TRACK PERSONALIZADO (línea)
-        track = { sliderState ->
-            val progressFraction = sliderState.value.coerceIn(0f..1f)
-
-            // Fondo (parte no reproducida)
-            Box(
-                modifier = Modifier
                     .fillMaxWidth()
-                    .height(4.dp) // Grosor de la barra
-                    .clip(RoundedCornerShape(percent = 50))
-                    .background(Color(0xFF3A3A3A)) // 🎨 COLOR DE LA LÍNEA DE FONDO (inactiva)
+                    .navigationBarsPadding()
+                    .padding(horizontal = 18.dp, vertical = 14.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                // Progreso (parte reproducida) con degradado
+                IconButton(onClick = { viewModel.toggleShuffleMode() }) {
+                    Icon(Icons.Default.Shuffle, null, tint = Color.White.copy(alpha = 0.75f))
+                }
+                IconButton(onClick = { viewModel.playPrevious() }, enabled = canPlayPrevious) {
+                    Icon(Icons.Default.SkipPrevious, null, tint = Color.White, modifier = Modifier.size(34.dp))
+                }
                 Box(
                     modifier = Modifier
-                        .fillMaxWidth(progressFraction)
-                        .fillMaxHeight()
-                        .background(
-                            brush = Brush.horizontalGradient(
-                                colors = listOf(
-                                    MaterialTheme.colorScheme.onSurface,                      // 🎨 Inicio del gradiente
-                                    Color(0xFFFF5000).copy(alpha = 0.3f) // 🎨 Fin translúcido
-                                )
-                            )
+                        .size(70.dp)
+                        .clip(CircleShape)
+                        .background(Brush.linearGradient(listOf(Color(0xFF7C3AED), Color(0xFF4F46E5)))),
+                    contentAlignment = Alignment.Center
+                ) {
+                    IconButton(onClick = { if (isPlaying) viewModel.pause() else viewModel.resume() }) {
+                        Icon(
+                            if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                            null,
+                            tint = Color.White,
+                            modifier = Modifier.size(34.dp)
                         )
-                )
+                    }
+                }
+                IconButton(onClick = { viewModel.playNext() }, enabled = canPlayNext) {
+                    Icon(Icons.Default.SkipNext, null, tint = Color.White, modifier = Modifier.size(34.dp))
+                }
+                IconButton(onClick = { viewModel.toggleRepeatMode() }) {
+                    Icon(Icons.Default.Repeat, null, tint = Color.White.copy(alpha = 0.75f))
+                }
+            }
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Brush.verticalGradient(listOf(Color(0xFF090B1A), Color(0xFF05060D))))
+                .padding(padding)
+                .padding(horizontal = 24.dp)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("Reproduciendo", color = Color.White, style = MaterialTheme.typography.titleLarge)
+                Row {
+                    IconButton(onClick = { showEqDialog = true }) {
+                        Icon(Icons.Default.Equalizer, contentDescription = "Ecualizador", tint = Color(0xFFA78BFA))
+                    }
+                    IconButton(onClick = { viewModel.toggleFavoriteStatus() }) {
+                        Icon(
+                            if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                            contentDescription = "Favorito",
+                            tint = if (isFavorite) Color(0xFFFB7185) else Color.White
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(18.dp))
+            Image(
+                painter = rememberAsyncImagePainter(
+                    model = if (currentSong!!.coverImage?.isEmpty() == true) R.drawable.ic_music_placeholder else currentSong!!.coverImage
+                ),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(320.dp)
+                    .clip(RoundedCornerShape(28.dp))
+                    .background(Color(0xFF111827))
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(currentSong!!.title, color = Color.White, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+            Text(currentSong!!.artistName, color = Color.White.copy(alpha = 0.6f), style = MaterialTheme.typography.bodyLarge)
+
+            Spacer(modifier = Modifier.height(24.dp))
+            Slider(
+                value = currentPosition.toFloat(),
+                onValueChange = { exoPlayer?.seekTo(it.toLong()) },
+                valueRange = 0f..duration.toFloat()
+            )
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(formatDuration(currentPosition), color = Color.White.copy(alpha = 0.7f))
+                Text(formatDuration(duration), color = Color.White.copy(alpha = 0.7f))
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+    }
+
+    if (showEqDialog) {
+        EqualizerDialog(
+            equalizer = equalizer,
+            onDismiss = { showEqDialog = false }
+        )
+    }
+}
+
+@Composable
+private fun EqualizerDialog(equalizer: PlayerEqualizer, onDismiss: () -> Unit) {
+    var refreshToken by remember { mutableStateOf(0) }
+    val isReady = remember(refreshToken) { equalizer.ensureReady() }
+    val presets = remember(refreshToken) { equalizer.presets() }
+    var selectedPreset by remember(refreshToken) { mutableStateOf(equalizer.currentPreset()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Ecualizador") },
+        text = {
+            if (!isReady) {
+                Text("El ecualizador se habilita cuando el audio está activo. Inicia la reproducción e inténtalo de nuevo.")
+            } else {
+                Column(modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState())) {
+                    Text("Presets", style = MaterialTheme.typography.titleSmall)
+                    Spacer(Modifier.height(8.dp))
+                    Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState())) {
+                        presets.forEach { (presetId, name) ->
+                            TextButton(onClick = {
+                                equalizer.usePreset(presetId)
+                                selectedPreset = presetId
+                                refreshToken++
+                            }) {
+                                Text(
+                                    text = name,
+                                    color = if (selectedPreset == presetId) Color(0xFF8B5CF6) else MaterialTheme.colorScheme.onSurface
+                                )
+                            }
+                        }
+                        TextButton(onClick = {
+                            selectedPreset = Equalizer.PRESET_UNDEFINED
+                            refreshToken++
+                        }) {
+                            Text(
+                                text = "Personalizado",
+                                color = if (selectedPreset == Equalizer.PRESET_UNDEFINED) Color(0xFF8B5CF6) else MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                    }
+
+                    Spacer(Modifier.height(12.dp))
+                    val range = equalizer.bandLevelRange()
+                    repeat(equalizer.bandCount()) { band ->
+                        val freq = equalizer.centerFreqHz(band)
+                        var bandLevel by remember(refreshToken, band) { mutableStateOf(equalizer.bandLevel(band).toFloat()) }
+                        Text("${freq}Hz", style = MaterialTheme.typography.bodySmall)
+                        Slider(
+                            value = bandLevel,
+                            onValueChange = {
+                                bandLevel = it
+                                equalizer.setBandLevel(band, it.toInt().toShort())
+                                selectedPreset = Equalizer.PRESET_UNDEFINED
+                            },
+                            valueRange = range.start.toFloat()..range.endInclusive.toFloat()
+                        )
+                    }
+                }
             }
         },
-
-        // 🎯 COLORES (se dejan transparentes porque el diseño es personalizado)
-        colors = SliderDefaults.colors(
-            thumbColor = Color.Unspecified,
-            activeTrackColor = Color.Transparent,
-            inactiveTrackColor = Color.Transparent
-        )
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Icon(Icons.Default.Settings, contentDescription = null)
+                Spacer(Modifier.width(6.dp))
+                Text("Cerrar")
+            }
+        }
     )
 }
 

--- a/app/src/main/java/com/example/pulseplayer/views/player/PlayerEqualizer.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/player/PlayerEqualizer.kt
@@ -1,0 +1,81 @@
+package com.example.pulseplayer.views.player
+
+import android.media.audiofx.Equalizer
+import androidx.media3.exoplayer.ExoPlayer
+
+class PlayerEqualizer(private val playerProvider: () -> ExoPlayer?) {
+    private var equalizer: Equalizer? = null
+    private var boundSessionId: Int? = null
+
+    fun ensureReady(): Boolean {
+        val player = playerProvider() ?: return false
+        val audioSessionId = player.audioSessionId
+        if (audioSessionId <= 0) return false
+
+        if (boundSessionId == audioSessionId && equalizer != null) return true
+
+        release()
+        return try {
+            equalizer = Equalizer(0, audioSessionId).apply { enabled = true }
+            boundSessionId = audioSessionId
+            true
+        } catch (_: Exception) {
+            equalizer = null
+            boundSessionId = null
+            false
+        }
+    }
+
+    fun bandLevelRange(): ClosedRange<Short> {
+        if (!ensureReady()) return (-1500).toShort()..1500.toShort()
+        val range = equalizer?.bandLevelRange
+        val min = range?.getOrNull(0) ?: (-1500).toShort()
+        val max = range?.getOrNull(1) ?: 1500.toShort()
+        return min..max
+    }
+
+    fun bandCount(): Int {
+        if (!ensureReady()) return 0
+        return equalizer?.numberOfBands?.toInt() ?: 0
+    }
+
+    fun bandLevel(index: Int): Short {
+        if (!ensureReady()) return 0
+        return equalizer?.getBandLevel(index.toShort()) ?: 0
+    }
+
+    fun setBandLevel(index: Int, value: Short) {
+        if (!ensureReady()) return
+        equalizer?.setBandLevel(index.toShort(), value)
+        equalizer?.usePreset(Equalizer.PRESET_UNDEFINED)
+    }
+
+    fun centerFreqHz(index: Int): Int {
+        if (!ensureReady()) return 0
+        return (equalizer?.getCenterFreq(index.toShort()) ?: 0) / 1000
+    }
+
+    fun presets(): List<Pair<Short, String>> {
+        if (!ensureReady()) return emptyList()
+        val eq = equalizer ?: return emptyList()
+        return (0 until eq.numberOfPresets).map { preset ->
+            preset to (eq.getPresetName(preset) ?: "Preset $preset")
+        }
+    }
+
+    fun currentPreset(): Short {
+        if (!ensureReady()) return Equalizer.PRESET_UNDEFINED
+        return equalizer?.currentPreset ?: Equalizer.PRESET_UNDEFINED
+    }
+
+    fun usePreset(preset: Short) {
+        if (!ensureReady()) return
+        equalizer?.usePreset(preset)
+    }
+
+    fun release() {
+        equalizer?.release()
+        equalizer = null
+        boundSessionId = null
+    }
+}

--- a/app/src/main/java/com/example/pulseplayer/views/playlist/PlaylistScreen.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/playlist/PlaylistScreen.kt
@@ -53,7 +53,7 @@ fun PlaylistScreen(navController: NavController) {
                         color = Color.White
                     )
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary),
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF090B1A)),
                 // Mostrar icono de eliminación en la TopAppBar si una playlist está seleccionada
                 actions = {
                     selectedPlaylistIdForDeletion?.let {
@@ -97,7 +97,7 @@ fun PlaylistScreen(navController: NavController) {
             }
 
         },
-        containerColor = MaterialTheme.colorScheme.background,
+        containerColor = Color(0xFF060911),
     ) { padding ->
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/example/pulseplayer/views/service/MusicPlayerService.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/service/MusicPlayerService.kt
@@ -1,6 +1,10 @@
 package com.example.pulseplayer.views.service
 
-import android.app.*
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -8,9 +12,6 @@ import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Build
 import android.os.IBinder
-import android.util.Log
-import android.widget.RemoteViews
-import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.media.app.NotificationCompat.MediaStyle
@@ -19,50 +20,45 @@ import androidx.media3.common.Player
 import com.example.pulseplayer.MainActivity
 import com.example.pulseplayer.R
 import com.example.pulseplayer.views.player.ExoPlayerManager
-import java.io.File
 
 class MusicPlayerService : Service() {
 
     override fun onCreate() {
         super.onCreate()
-        Log.d("MusicPlayerService", "✅ onCreate llamado")
-        // ✅ accede al player correctamente
         ExoPlayerManager.getPlayer()?.addListener(object : Player.Listener {
-
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-                showCustomNotification()
+                showPlayerNotification()
             }
 
             override fun onIsPlayingChanged(isPlaying: Boolean) {
-                showCustomNotification()
+                showPlayerNotification()
             }
         })
         createNotificationChannel()
-        showCustomNotification()
+        showPlayerNotification()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
-            "ACTION_PLAY" -> ExoPlayerManager.resume()
-            "ACTION_PAUSE" -> ExoPlayerManager.pause()
-            "ACTION_NEXT" -> ExoPlayerManager.playNext()
-            "ACTION_PREV" -> ExoPlayerManager.playPrevious()
-            "ACTION_STOP" -> {
+            ACTION_PLAY -> ExoPlayerManager.resume()
+            ACTION_PAUSE -> ExoPlayerManager.pause()
+            ACTION_NEXT -> ExoPlayerManager.playNext()
+            ACTION_PREV -> ExoPlayerManager.playPrevious()
+            ACTION_STOP -> {
                 ExoPlayerManager.pause()
-                stopForeground(true)
+                stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
                 return START_NOT_STICKY
             }
         }
 
-        showCustomNotification()
+        showPlayerNotification()
         return START_STICKY
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        Log.d("MusicPlayerService", "🛑 Servicio detenido")
-        stopForeground(true)
+        stopForeground(STOP_FOREGROUND_REMOVE)
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -70,11 +66,12 @@ class MusicPlayerService : Service() {
     private fun createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
-                "pulseplayer_channel",
+                CHANNEL_ID,
                 "PulsePlayer",
                 NotificationManager.IMPORTANCE_LOW
             ).apply {
-                description = "Control de reproducción de PulsePlayer"
+                description = "Controles de reproducción"
+                setShowBadge(false)
                 lockscreenVisibility = Notification.VISIBILITY_PUBLIC
             }
             val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -82,88 +79,75 @@ class MusicPlayerService : Service() {
         }
     }
 
-    private fun showCustomNotification() {
-        val player = ExoPlayerManager.getPlayer()
+    private fun showPlayerNotification() {
         val song = ExoPlayerManager.getCurrentSong() ?: return
-        val isPlaying = player?.isPlaying == true
+        val isPlaying = ExoPlayerManager.getPlayer()?.isPlaying == true
 
-        // Intents para los botones
-        val playPauseIntent = Intent(this, MusicPlayerService::class.java).apply {
-            action = if (isPlaying) "ACTION_PAUSE" else "ACTION_PLAY"
-        }
-        val prevIntent = Intent(this, MusicPlayerService::class.java).apply {
-            action = "ACTION_PREV"
-        }
-        val nextIntent = Intent(this, MusicPlayerService::class.java).apply {
-            action = "ACTION_NEXT"
-        }
-        val stopIntent = Intent(this, MusicPlayerService::class.java).apply {
-            action = "ACTION_STOP"
-        }
+        val openAppIntent = PendingIntent.getActivity(
+            this,
+            20,
+            Intent(this, MainActivity::class.java).apply { flags = Intent.FLAG_ACTIVITY_SINGLE_TOP },
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
 
-        // PendingIntents
-        val playPausePendingIntent = PendingIntent.getService(this, 0, playPauseIntent, PendingIntent.FLAG_IMMUTABLE)
-        val prevPendingIntent = PendingIntent.getService(this, 1, prevIntent, PendingIntent.FLAG_IMMUTABLE)
-        val nextPendingIntent = PendingIntent.getService(this, 2, nextIntent, PendingIntent.FLAG_IMMUTABLE)
-        val stopPendingIntent = PendingIntent.getService(this, 3, stopIntent, PendingIntent.FLAG_IMMUTABLE)
+        val prevIntent = actionIntent(ACTION_PREV, 1)
+        val playPauseIntent = actionIntent(if (isPlaying) ACTION_PAUSE else ACTION_PLAY, 2)
+        val nextIntent = actionIntent(ACTION_NEXT, 3)
+        val stopIntent = actionIntent(ACTION_STOP, 4)
 
-        // RemoteViews personalizados
-        val remoteViews = RemoteViews(packageName, R.layout.notification_music_player).apply {
-            setTextViewText(R.id.text_title, song.title.ifEmpty { "Título desconocido" })
-            setTextViewText(R.id.text_artist, song.artistName.ifEmpty { "Artista desconocido" })
+        val artwork = getBitmapFromUri(song.coverImage)
 
-            // Cargar portada desde URI
-            val bitmap = getBitmapFromUri(song.coverImage)
-            if (bitmap != null) {
-                setImageViewBitmap(R.id.image_cover, bitmap)
-            } else {
-                setImageViewResource(R.id.image_cover, R.drawable.ic_music_placeholder)
-            }
-
-            // Botón play/pause
-            setImageViewResource(
-                R.id.btn_play_pause,
-                if (isPlaying) R.drawable.pause2_icon else R.drawable.play2_icon
-            )
-            setOnClickPendingIntent(R.id.btn_play_pause, playPausePendingIntent)
-
-            // Botones anteriores/siguiente/cerrar
-            setImageViewResource(R.id.btn_prev, R.drawable.back2_icon)
-            setImageViewResource(R.id.btn_next, R.drawable.skip2_icon)
-            setImageViewResource(R.id.btn_close, R.drawable.stop_icon)
-
-            setOnClickPendingIntent(R.id.btn_prev, prevPendingIntent)
-            setOnClickPendingIntent(R.id.btn_next, nextPendingIntent)
-            setOnClickPendingIntent(R.id.btn_close, stopPendingIntent)
-        }
-
-        // Construcción de la notificación
-        val notification = NotificationCompat.Builder(this, "pulseplayer_channel")
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.logo_ico)
             .setColor(ContextCompat.getColor(this, R.color.pulse_blue))
-            .setStyle(NotificationCompat.DecoratedCustomViewStyle())
-            .setCustomContentView(remoteViews)
-            .setPriority(NotificationCompat.PRIORITY_LOW)
-            .setOngoing(true)
+            .setContentTitle(song.title.ifBlank { "Pulse Player" })
+            .setContentText(song.artistName.ifBlank { "Artista desconocido" })
+            .setLargeIcon(artwork)
+            .setContentIntent(openAppIntent)
+            .setDeleteIntent(stopIntent)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setOnlyAlertOnce(true)
+            .setOngoing(isPlaying)
+            .addAction(R.drawable.back2_icon, getString(R.string.previous), prevIntent)
+            .addAction(
+                if (isPlaying) R.drawable.pause2_icon else R.drawable.play2_icon,
+                if (isPlaying) getString(R.string.pause) else getString(R.string.play),
+                playPauseIntent
+            )
+            .addAction(R.drawable.skip2_icon, getString(R.string.next), nextIntent)
+            .setStyle(MediaStyle().setShowActionsInCompactView(0, 1, 2))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()
 
-        startForeground(1, notification)
+        startForeground(NOTIFICATION_ID, notification)
+    }
+
+    private fun actionIntent(action: String, requestCode: Int): PendingIntent {
+        return PendingIntent.getService(
+            this,
+            requestCode,
+            Intent(this, MusicPlayerService::class.java).setAction(action),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
     }
 
     private fun getBitmapFromUri(uriString: String?): Bitmap? {
         if (uriString.isNullOrEmpty()) return null
         return try {
             val uri = Uri.parse(uriString)
-            contentResolver.openInputStream(uri)?.use {
-                BitmapFactory.decodeStream(it)
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
+            contentResolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it) }
+        } catch (_: Exception) {
             null
         }
     }
 
-
-
+    companion object {
+        private const val CHANNEL_ID = "pulseplayer_channel"
+        private const val NOTIFICATION_ID = 1
+        private const val ACTION_PLAY = "ACTION_PLAY"
+        private const val ACTION_PAUSE = "ACTION_PAUSE"
+        private const val ACTION_NEXT = "ACTION_NEXT"
+        private const val ACTION_PREV = "ACTION_PREV"
+        private const val ACTION_STOP = "ACTION_STOP"
+    }
 }


### PR DESCRIPTION
### Motivation
- Modernize the app UI with a refreshed look for the menu, music list and mini player and add an Albums browsing screen. 
- Improve foreground service behavior and notifications to be more reliable and actionable. 
- Provide per-session audio control via an in-app equalizer and enable required audio permission. 

### Description
- Added `android.permission.MODIFY_AUDIO_SETTINGS` to `AndroidManifest.xml` for equalizer support. 
- Main activity lifecycle: request permissions on start and stop the `MusicPlayerService` when the app returns to foreground, and cancel the notification. 
- Navigation: added an `Albums` route and wired `AlbumsScreen` into `NavController`. 
- New `AlbumsScreen` component that groups songs by album and launches playback for an album. 
- Redesigned `MiniPlayerBar` with updated visuals, previous/next buttons, a central play/pause control and gradient styling. 
- Revised `MusicScreen` and `SongCardItem` with new layout, coloring and image handling (using `AsyncImage`) for a cohesive theme. 
- Large `MenuScreen` overhaul to a home-style layout with library categories, hero card, bottom nav strip and dynamic counts for albums/playlists. 
- Reworked `NowPlayingScreen` UI and logic to use ViewModel observables, show loading state, provide improved playback controls, seek slider, favorite toggle and an Equalizer dialog. 
- Added `PlayerEqualizer` helper class to manage Android `Equalizer` tied to the player's audio session, with band presets and band controls. 
- Updated `MusicPlayerService` to centralize notification channel and action constants, build a media-style notification with actions (`prev/play/pause/next/stop`), improved PendingIntent flags, and use `startForeground`/`stopForeground` with named constants. 

### Testing
- Performed a local debug build smoke check using `./gradlew assembleDebug` to validate integration of new screens and service changes. 
- No automated unit or instrumentation tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1cc7f998483259a7bb0b07a35864c)