### PR TITLE
Dynamic album glow color extraction and custom seek bar with gesture support

### DIFF
--- a/app/src/main/java/com/example/pulseplayer/views/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/player/NowPlayingScreen.kt
@@ -1,8 +1,12 @@
 package com.example.pulseplayer.views.player
 
+import android.graphics.Bitmap
+import android.graphics.Color as AndroidColor
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -41,7 +46,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -49,6 +53,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -57,6 +62,8 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -64,11 +71,17 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import androidx.core.graphics.drawable.toBitmap
 import coil.compose.rememberAsyncImagePainter
+import coil.imageLoader
+import coil.request.ImageRequest
+import coil.request.SuccessResult
 import com.example.pulseplayer.R
 import com.example.pulseplayer.data.PulsePlayerDatabase
 import com.example.pulseplayer.views.viewmodel.PlayerViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 
 @Composable
 fun NowPlayingScreen(
@@ -123,7 +136,7 @@ fun NowPlayingScreen(
         return
     }
 
-    val glowColor = remember(song.coverImage) { glowColorFromCover(song.coverImage) }
+    val glowColor by rememberDynamicGlowColor(song.coverImage)
 
     Scaffold(
         containerColor = Color(0xFF05060D),
@@ -292,14 +305,14 @@ private fun AlbumArtWithGlow(coverImage: String?, glowColor: Color, size: androi
         Box(
             modifier = Modifier
                 .size(size + 120.dp)
-                .blur(62.dp)
-                .background(glowColor.copy(alpha = 0.26f), CircleShape)
+                .blur(72.dp)
+                .background(glowColor.copy(alpha = 0.34f), CircleShape)
         )
         Box(
             modifier = Modifier
                 .size(size + 64.dp)
-                .blur(34.dp)
-                .background(glowColor.copy(alpha = 0.34f), RoundedCornerShape(44.dp))
+                .blur(40.dp)
+                .background(glowColor.copy(alpha = 0.42f), RoundedCornerShape(44.dp))
         )
 
         Box(
@@ -329,21 +342,76 @@ private fun SongTexts(song: com.example.pulseplayer.data.entity.Song) {
 
 @Composable
 private fun PlayerProgress(currentPosition: Long, duration: Long, onSeek: (Float) -> Unit) {
-    Slider(
-        value = currentPosition.coerceAtMost(duration).toFloat(),
-        onValueChange = onSeek,
-        valueRange = 0f..duration.toFloat(),
-        colors = SliderDefaults.colors(
-            thumbColor = Color(0xFF6D4AFF),
-            activeTrackColor = Color.White.copy(alpha = 0.24f),
-            inactiveTrackColor = Color.White.copy(alpha = 0.24f)
+    val safeDuration = duration.coerceAtLeast(1L)
+    val progressFraction = (currentPosition.coerceAtMost(safeDuration).toFloat() / safeDuration.toFloat()).coerceIn(0f, 1f)
+
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(18.dp)
+            .pointerInput(safeDuration) {
+                val width = size.width.toFloat().coerceAtLeast(1f)
+
+                fun positionToValue(x: Float): Float {
+                    val normalized = (x / width).coerceIn(0f, 1f)
+                    return normalized * safeDuration.toFloat()
+                }
+
+                detectTapGestures { offset ->
+                    onSeek(positionToValue(offset.x))
+                }
+            }
+            .pointerInput(safeDuration) {
+                val width = size.width.toFloat().coerceAtLeast(1f)
+
+                fun positionToValue(x: Float): Float {
+                    val normalized = (x / width).coerceIn(0f, 1f)
+                    return normalized * safeDuration.toFloat()
+                }
+
+                detectDragGestures { change, _ ->
+                    onSeek(positionToValue(change.position.x))
+                }
+            }
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(3.dp)
+                .align(Alignment.CenterStart)
+                .clip(CircleShape)
+                .background(Color.White.copy(alpha = 0.22f))
         )
-    )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(progressFraction)
+                .height(3.dp)
+                .align(Alignment.CenterStart)
+                .clip(CircleShape)
+                .background(Color.White.copy(alpha = 0.30f))
+        )
+
+        val thumbDiameter = 10.dp
+        val thumbCenterX = (maxWidth * progressFraction)
+        val maxThumbOffset = (maxWidth - thumbDiameter).coerceAtLeast(0.dp)
+        val thumbOffset = (thumbCenterX - (thumbDiameter / 2)).coerceIn(0.dp, maxThumbOffset)
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .offset(x = thumbOffset)
+                .size(thumbDiameter)
+                .clip(CircleShape)
+                .background(Color(0xFF6D4AFF))
+        )
+    }
+
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
         Text(formatDuration(currentPosition), color = Color(0xFFA8B0C8), style = MaterialTheme.typography.labelMedium)
         Text(formatDuration(duration), color = Color(0xFFA8B0C8), style = MaterialTheme.typography.labelMedium)
     }
 }
+
 @Composable
 private fun ModeButtons(isFavorite: Boolean, onShuffle: () -> Unit, onRepeat: () -> Unit, onFavorite: () -> Unit, onEq: () -> Unit) {
     Row(
@@ -396,17 +464,74 @@ private fun MainTransportButtons(
     }
 }
 
-private fun glowColorFromCover(cover: String?): Color {
-    if (cover.isNullOrBlank()) return Color(0xFF6D4AFF)
-    val palette = listOf(
-        Color(0xFF6D4AFF),
-        Color(0xFF4F46E5),
-        Color(0xFF7C3AED),
-        Color(0xFF2563EB),
-        Color(0xFF9333EA)
-    )
-    val index = kotlin.math.abs(cover.hashCode()) % palette.size
-    return palette[index]
+@Composable
+private fun rememberDynamicGlowColor(coverImage: String?): androidx.compose.runtime.State<Color> {
+    val context = LocalContext.current
+    return produceState(initialValue = Color(0xFF6D4AFF), coverImage) {
+        value = extractDominantGlowColor(context.imageLoader, context, coverImage) ?: Color(0xFF6D4AFF)
+    }
+}
+
+private suspend fun extractDominantGlowColor(
+    imageLoader: coil.ImageLoader,
+    context: android.content.Context,
+    coverImage: String?
+): Color? {
+    if (coverImage.isNullOrBlank()) return null
+    return withContext(Dispatchers.IO) {
+        runCatching {
+            val request = ImageRequest.Builder(context)
+                .data(coverImage)
+                .size(64, 64)
+                .allowHardware(false)
+                .build()
+            val result = imageLoader.execute(request) as? SuccessResult ?: return@withContext null
+            val bitmap = result.drawable.toBitmap(64, 64, Bitmap.Config.ARGB_8888)
+            dominantColorFromBitmap(bitmap)
+        }.getOrNull()
+    }
+}
+
+private fun dominantColorFromBitmap(bitmap: Bitmap): Color {
+    var r = 0f
+    var g = 0f
+    var b = 0f
+    var weightSum = 0f
+
+    val widthStep = (bitmap.width / 20).coerceAtLeast(1)
+    val heightStep = (bitmap.height / 20).coerceAtLeast(1)
+
+    for (x in 0 until bitmap.width step widthStep) {
+        for (y in 0 until bitmap.height step heightStep) {
+            val pixel = bitmap.getPixel(x, y)
+            val red = AndroidColor.red(pixel)
+            val green = AndroidColor.green(pixel)
+            val blue = AndroidColor.blue(pixel)
+
+            val maxChannel = maxOf(red, green, blue).toFloat()
+            val minChannel = minOf(red, green, blue).toFloat()
+            val saturation = if (maxChannel == 0f) 0f else (maxChannel - minChannel) / maxChannel
+            val weight = 0.35f + saturation
+
+            r += red * weight
+            g += green * weight
+            b += blue * weight
+            weightSum += weight
+        }
+    }
+
+    if (weightSum == 0f) return Color(0xFF6D4AFF)
+
+    val rawColor = Color((r / weightSum) / 255f, (g / weightSum) / 255f, (b / weightSum) / 255f, 1f)
+    val boosted = rawColor.copy(alpha = 1f)
+    return if (boosted.luminance() < 0.15f) {
+        boosted.copy(
+            red = (boosted.red + 0.20f).coerceAtMost(1f),
+            blue = (boosted.blue + 0.20f).coerceAtMost(1f)
+        )
+    } else {
+        boosted
+    }
 }
 
 @Composable


### PR DESCRIPTION
### Motivation

- Replace the static hash-based glow palette with a visually accurate glow color derived from the album cover to improve UI cohesion.
- Replace the Material `Slider` with a custom, gesture-driven progress bar to provide more precise tap/drag seeking and a custom-styled thumb.

### Description

- Implemented `rememberDynamicGlowColor` which uses Coil to load the cover image off the UI thread and computes a weighted dominant color via `dominantColorFromBitmap`, replacing `glowColorFromCover`.
- Added image loading utilities (`ImageRequest`, `imageLoader`, `toBitmap`) and coroutine dispatching (`produceState`, `withContext`, `Dispatchers.IO`) to safely extract bitmap data in the background.
- Adjusted album art glow visuals by increasing blur radii and alpha values to enhance the glow effect around the cover art.
- Replaced the `Slider` in `PlayerProgress` with a custom `BoxWithConstraints` implementation that handles taps and drags via `pointerInput`, `detectTapGestures`, and `detectDragGestures`, and draws a progress track, filled portion, and a movable thumb.

### Testing

- Performed a debug assemble with `./gradlew assembleDebug` which completed successfully.
- Ran unit tests with `./gradlew test` and the test task completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ee98e7708325b708d117550351a6)