### PR TITLE
Unify playlist creation UI with playlist section styling

### DIFF
--- a/app/src/main/java/com/example/pulseplayer/views/playlist/PlaylistCreateScreen.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/playlist/PlaylistCreateScreen.kt
@@ -1,12 +1,17 @@
 package com.example.pulseplayer.views.playlist
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.QueueMusic
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -34,13 +39,19 @@ fun PlaylistCreateScreen(navController: NavController) {
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.playlist_add), color = Color.White) },
+                title = {
+                    Text(
+                        text = stringResource(R.string.playlist_add),
+                        fontSize = 20.sp,
+                        color = Color.White,
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
                         Icon(Icons.Default.ArrowBack, contentDescription = null, tint = Color.White)
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary),
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF090B1A)),
             )
         },
         bottomBar = {
@@ -49,57 +60,103 @@ fun PlaylistCreateScreen(navController: NavController) {
                 modifier = Modifier.fillMaxWidth().wrapContentHeight().navigationBarsPadding(),
             )
         },
-        containerColor = MaterialTheme.colorScheme.background,
+        containerColor = Color(0xFF060911),
     ) { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .padding(24.dp),
+                .padding(20.dp),
             verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            OutlinedTextField(
-                value = name,
-                onValueChange = { name = it },
-                label = { Text("Nombre ${stringResource(R.string.playlist_screen_title)}") },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedContainerColor = Color.DarkGray,
-                    unfocusedContainerColor = Color.DarkGray,
-                    focusedBorderColor = Color.White,
-                    unfocusedBorderColor = Color.LightGray,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.Gray
-                )
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Button(
-                onClick = {
-                    if (name.isNotBlank()) {
-                        val dao = PulsePlayerDatabase.getDatabase(context).playlistDao()
-                        val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
-                        val newPlaylist = Playlist(name = name, createdAt = formatter.format(Date()))
-
-                        scope.launch {
-                            withContext(Dispatchers.IO) {
-                                dao.insert(newPlaylist)
-                            }
-                            navController.popBackStack()
-                        }
-                    }
-                },
-                modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF56ab2f))
+            Card(
+                shape = RoundedCornerShape(24.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        brush = Brush.linearGradient(
+                            listOf(Color(0xFF13203C), Color(0xFF0A132B))
+                        ),
+                        shape = RoundedCornerShape(24.dp)
+                    )
+                    .border(1.dp, Color.White.copy(alpha = 0.08f), RoundedCornerShape(24.dp))
             ) {
-                Text("Crear lista", fontWeight = FontWeight.Bold, fontSize = 16.sp)
-            }
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.QueueMusic,
+                        contentDescription = null,
+                        tint = Color(0xFF60A5FA),
+                        modifier = Modifier.size(32.dp)
+                    )
+                    Spacer(modifier = Modifier.height(10.dp))
+                    Text(
+                        text = "Crea una nueva lista",
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 18.sp
+                    )
+                    Text(
+                        text = "Usa el mismo estilo visual de tus listas actuales.",
+                        color = Color.White.copy(alpha = 0.6f),
+                        fontSize = 13.sp,
+                        modifier = Modifier.padding(top = 4.dp, bottom = 18.dp)
+                    )
 
+                    OutlinedTextField(
+                        value = name,
+                        onValueChange = { name = it },
+                        label = { Text("Nombre de la lista") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(14.dp),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedTextColor = Color.White,
+                            unfocusedTextColor = Color.White,
+                            focusedContainerColor = Color.White.copy(alpha = 0.04f),
+                            unfocusedContainerColor = Color.White.copy(alpha = 0.04f),
+                            focusedBorderColor = Color(0xFF60A5FA),
+                            unfocusedBorderColor = Color.White.copy(alpha = 0.16f),
+                            focusedLabelColor = Color(0xFF60A5FA),
+                            unfocusedLabelColor = Color.White.copy(alpha = 0.58f)
+                        )
+                    )
+
+                    Spacer(modifier = Modifier.height(18.dp))
+
+                    Button(
+                        onClick = {
+                            if (name.isNotBlank()) {
+                                val dao = PulsePlayerDatabase.getDatabase(context).playlistDao()
+                                val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+                                val newPlaylist = Playlist(name = name.trim(), createdAt = formatter.format(Date()))
+
+                                scope.launch {
+                                    withContext(Dispatchers.IO) {
+                                        dao.insert(newPlaylist)
+                                    }
+                                    navController.popBackStack()
+                                }
+                            }
+                        },
+                        enabled = name.isNotBlank(),
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFF9C27B0),
+                            contentColor = Color.White,
+                            disabledContainerColor = Color(0xFF9C27B0).copy(alpha = 0.35f),
+                            disabledContentColor = Color.White.copy(alpha = 0.65f)
+                        )
+                    ) {
+                        Text("Crear lista", fontWeight = FontWeight.Bold, fontSize = 16.sp)
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Make the playlist creation screen visually consistent with the existing playlist/list cards and library views so newly created playlists share the same look & feel.
- Improve UX by providing a clearer, polished form layout and preventing empty/whitespace-only playlist names from being saved.

### Description
- Restyled `PlaylistCreateScreen` to use a dark top bar and deep background (`Color(0xFF090B1A)` and `Color(0xFF060911)`) matching the playlist section visuals and wrapped the form in a gradient `Card` with rounded corners and a subtle border.
- Replaced the simple `OutlinedTextField` layout with a centered card block that includes an icon, title, subtitle, and an `OutlinedTextField` with adjusted colors and rounded shape to match existing components.
- Updated the create `Button` to use the purple accent (`Color(0xFF9C27B0)`), disable when the name is blank, and trim the playlist name (`name.trim()`) before inserting into the database.
- Changes are contained in `app/src/main/java/com/example/pulseplayer/views/playlist/PlaylistCreateScreen.kt` and do not alter navigation or database schema.

### Testing
- Attempted to run an automated build with `./gradlew :app:compileDebugKotlin`, but the Gradle wrapper download failed due to a network/proxy restriction (`HTTP/1.1 403 Forbidden`), so the build could not be validated in this environment.
- No unit/UI tests were run in this environment beyond the attempted compile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2115abb7c83258020c48a9b7f67e8)