### PR TITLE
Playlist screens: dark UI restyle, navigation & coroutine DB fixes

### DIFF
--- a/app/src/main/java/com/example/pulseplayer/views/playlist/AddSongsToPlaylistScreen.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/playlist/AddSongsToPlaylistScreen.kt
@@ -1,4 +1,4 @@
-package com.example.pulseplayer.views.playlist // Asegúrate de que este sea el paquete correcto
+package com.example.pulseplayer.views.playlist
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.Image
@@ -11,21 +11,20 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.* // Importar todo de Material3 para asegurar acceso
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import coil.compose.rememberAsyncImagePainter
 import com.example.pulseplayer.R
@@ -34,10 +33,9 @@ import com.example.pulseplayer.data.entity.PlaylistSong
 import com.example.pulseplayer.data.entity.Song
 import com.example.pulseplayer.isLandscape
 import com.example.pulseplayer.ui.components.MiniPlayerBar
-import com.example.pulseplayer.views.viewmodel.PlayerViewModel // Puede que necesites este si MiniPlayerBar lo usa
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -50,11 +48,11 @@ fun AddSongsToPlaylistScreen(navController: NavController, playlistId: Int) {
     val songDao = remember { PulsePlayerDatabase.getDatabase(context).songDao() }
     val playlistSongDao = remember { PulsePlayerDatabase.getDatabase(context).playlistSongDao() }
 
-    val selectedSongs = remember { mutableStateListOf<Song>() } // Usamos mutableStateListOf para observables de lista
+    val selectedSongs = remember { mutableStateListOf<Song>() }
 
     LaunchedEffect(Unit) {
         scope.launch(Dispatchers.IO) {
-            allSongs = songDao.getAll().first() // Obtener todas las canciones una sola vez
+            allSongs = songDao.getAll().first()
         }
     }
 
@@ -64,79 +62,45 @@ fun AddSongsToPlaylistScreen(navController: NavController, playlistId: Int) {
                 title = {
                     Text(
                         text = stringResource(R.string.playlist_add_song),
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = MaterialTheme.colorScheme.onPrimary,
+                        color = Color.White,
+                        fontSize = 34.sp,
                     )
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary),
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null, tint = Color.White)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF090B1A)),
             )
         },
         floatingActionButton = {
             val isFabEnabled = selectedSongs.isNotEmpty()
 
-            if (isLandscape()) {
-                FloatingActionButton(
-                    onClick = {
-                        if (isFabEnabled) {
-                            scope.launch(Dispatchers.IO) { // Ejecuta la inserción en el hilo de fondo
-                                var currentOrder = 0
-
-                                selectedSongs.forEach { song ->
-                                    playlistSongDao.insert(
-                                        PlaylistSong(
-                                            playlistId = playlistId,
-                                            songId = song.idSong,
-                                            songOrder = currentOrder++
-                                        )
+            val fabModifier = if (isLandscape()) Modifier.navigationBarsPadding() else Modifier
+            FloatingActionButton(
+                onClick = {
+                    if (isFabEnabled) {
+                        scope.launch(Dispatchers.IO) {
+                            var currentOrder = 0
+                            selectedSongs.forEach { song ->
+                                playlistSongDao.insert(
+                                    PlaylistSong(
+                                        playlistId = playlistId,
+                                        songId = song.idSong,
+                                        songOrder = currentOrder++
                                     )
-                                }
-                                // Después de la operación de base de datos, cambia al hilo principal para navegar
-                                withContext(Dispatchers.Main) {
-                                    navController.popBackStack() // <<<<<<<<<<<<<< AHORA EN EL HILO PRINCIPAL
-                                }
+                                )
                             }
+                            withContext(Dispatchers.Main) { navController.popBackStack() }
                         }
-                    },
-                    containerColor = Color(0xFF9C27B0),
-                    contentColor = Color.White,
-                    modifier = Modifier.navigationBarsPadding(),
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Check, // Usar imageVector
-                        contentDescription = "Añadir seleccionadas"
-                    )
-                }
-            } else {
-                FloatingActionButton(
-                    onClick = {
-                        if (isFabEnabled) {
-                            scope.launch(Dispatchers.IO) { // Ejecuta la inserción en el hilo de fondo
-                                var currentOrder = 0
-
-                                selectedSongs.forEach { song ->
-                                    playlistSongDao.insert(
-                                        PlaylistSong(
-                                            playlistId = playlistId,
-                                            songId = song.idSong,
-                                            songOrder = currentOrder++
-                                        )
-                                    )
-                                }
-                                // Después de la operación de base de datos, cambia al hilo principal para navegar
-                                withContext(Dispatchers.Main) {
-                                    navController.popBackStack() // <<<<<<<<<<<<<< AHORA EN EL HILO PRINCIPAL
-                                }
-                            }
-                        }
-                    },
-                    containerColor = Color(0xFF9C27B0),
-                    contentColor = Color.White,
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Check, // Usar imageVector
-                        contentDescription = "Añadir seleccionadas"
-                    )
-                }
+                    }
+                },
+                containerColor = Color(0xFF9C27B0),
+                contentColor = Color.White,
+                modifier = fabModifier,
+            ) {
+                Icon(imageVector = Icons.Default.Check, contentDescription = "Añadir seleccionadas")
             }
         },
         bottomBar = {
@@ -145,13 +109,13 @@ fun AddSongsToPlaylistScreen(navController: NavController, playlistId: Int) {
                 modifier = Modifier.fillMaxWidth().wrapContentHeight().navigationBarsPadding(),
             )
         },
-        containerColor = MaterialTheme.colorScheme.background,
+        containerColor = Color(0xFF060911),
     ) { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .background(MaterialTheme.colorScheme.background)
+                .background(Color(0xFF060911))
         ) {
             if (allSongs.isEmpty()) {
                 Box(
@@ -160,8 +124,7 @@ fun AddSongsToPlaylistScreen(navController: NavController, playlistId: Int) {
                 ) {
                     Text(
                         text = "No hay canciones disponibles.",
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        color = Color.White.copy(alpha = 0.5f),
                     )
                 }
             } else {
@@ -192,26 +155,31 @@ fun AddSongsToPlaylistScreen(navController: NavController, playlistId: Int) {
 @Composable
 fun SelectableSongCardItem(song: Song, isSelected: Boolean, onClick: () -> Unit) {
     val borderColor by animateColorAsState(
-        targetValue = if (isSelected) Color(0xFF9C27B0) else Color.Transparent,
+        targetValue = if (isSelected) Color(0xFF9C27B0) else Color.White.copy(alpha = 0.07f),
         label = "borderColor"
     )
-    val backgroundColor by animateColorAsState(
-        targetValue = if (isSelected) Color(0xFF3A004C) else Color(0xFF1C1C1E),
-        label = "backgroundColor"
+    val iconColor by animateColorAsState(
+        targetValue = if (isSelected) Color(0xFFC968FF) else Color.White.copy(alpha = 0.5f),
+        label = "iconColor"
     )
 
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp, vertical = 6.dp)
-            .border(2.dp, borderColor, shape = RoundedCornerShape(16.dp))
+            .border(1.dp, borderColor, shape = RoundedCornerShape(18.dp))
             .clickable { onClick() },
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
-        shape = RoundedCornerShape(16.dp)
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+        shape = RoundedCornerShape(18.dp)
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .background(
+                    brush = Brush.linearGradient(
+                        listOf(Color(0xFF121A31), Color(0xFF0A132B))
+                    )
+                )
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -234,28 +202,30 @@ fun SelectableSongCardItem(song: Song, isSelected: Boolean, onClick: () -> Unit)
                 Text(
                     text = song.title,
                     style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    color = Color.White,
                 )
                 Text(
-                    text = song.title,
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    text = song.artistName,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.White.copy(alpha = 0.62f),
                 )
             }
 
             if (isSelected) {
                 Icon(
-                    imageVector = Icons.Default.Check, // Usar imageVector
+                    imageVector = Icons.Default.Check,
                     contentDescription = "Seleccionado",
-                    tint = Color(0xFF9C27B0),
-                    modifier = Modifier.size(24.dp).padding(end = 4.dp)
+                    tint = iconColor,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .padding(end = 4.dp)
                 )
             }
 
             Text(
                 text = song.formattedDuration,
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = Color.White.copy(alpha = 0.88f),
             )
         }
     }

--- a/app/src/main/java/com/example/pulseplayer/views/playlist/PlaylistCreateScreen.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/playlist/PlaylistCreateScreen.kt
@@ -1,12 +1,17 @@
 package com.example.pulseplayer.views.playlist
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.QueueMusic
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -34,13 +39,19 @@ fun PlaylistCreateScreen(navController: NavController) {
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.playlist_add), color = Color.White) },
+                title = {
+                    Text(
+                        text = stringResource(R.string.playlist_add),
+                        fontSize = 20.sp,
+                        color = Color.White,
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
                         Icon(Icons.Default.ArrowBack, contentDescription = null, tint = Color.White)
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary),
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF090B1A)),
             )
         },
         bottomBar = {
@@ -49,57 +60,103 @@ fun PlaylistCreateScreen(navController: NavController) {
                 modifier = Modifier.fillMaxWidth().wrapContentHeight().navigationBarsPadding(),
             )
         },
-        containerColor = MaterialTheme.colorScheme.background,
+        containerColor = Color(0xFF060911),
     ) { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .padding(24.dp),
+                .padding(20.dp),
             verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            OutlinedTextField(
-                value = name,
-                onValueChange = { name = it },
-                label = { Text("Nombre ${stringResource(R.string.playlist_screen_title)}") },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedContainerColor = Color.DarkGray,
-                    unfocusedContainerColor = Color.DarkGray,
-                    focusedBorderColor = Color.White,
-                    unfocusedBorderColor = Color.LightGray,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.Gray
-                )
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Button(
-                onClick = {
-                    if (name.isNotBlank()) {
-                        val dao = PulsePlayerDatabase.getDatabase(context).playlistDao()
-                        val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
-                        val newPlaylist = Playlist(name = name, createdAt = formatter.format(Date()))
-
-                        scope.launch {
-                            withContext(Dispatchers.IO) {
-                                dao.insert(newPlaylist)
-                            }
-                            navController.popBackStack()
-                        }
-                    }
-                },
-                modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF56ab2f))
+            Card(
+                shape = RoundedCornerShape(24.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        brush = Brush.linearGradient(
+                            listOf(Color(0xFF13203C), Color(0xFF0A132B))
+                        ),
+                        shape = RoundedCornerShape(24.dp)
+                    )
+                    .border(1.dp, Color.White.copy(alpha = 0.08f), RoundedCornerShape(24.dp))
             ) {
-                Text("Crear lista", fontWeight = FontWeight.Bold, fontSize = 16.sp)
-            }
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.QueueMusic,
+                        contentDescription = null,
+                        tint = Color(0xFF60A5FA),
+                        modifier = Modifier.size(32.dp)
+                    )
+                    Spacer(modifier = Modifier.height(10.dp))
+                    Text(
+                        text = "Crea una nueva lista",
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 18.sp
+                    )
+                    Text(
+                        text = "Usa el mismo estilo visual de tus listas actuales.",
+                        color = Color.White.copy(alpha = 0.6f),
+                        fontSize = 13.sp,
+                        modifier = Modifier.padding(top = 4.dp, bottom = 18.dp)
+                    )
 
+                    OutlinedTextField(
+                        value = name,
+                        onValueChange = { name = it },
+                        label = { Text("Nombre de la lista") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(14.dp),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedTextColor = Color.White,
+                            unfocusedTextColor = Color.White,
+                            focusedContainerColor = Color.White.copy(alpha = 0.04f),
+                            unfocusedContainerColor = Color.White.copy(alpha = 0.04f),
+                            focusedBorderColor = Color(0xFF60A5FA),
+                            unfocusedBorderColor = Color.White.copy(alpha = 0.16f),
+                            focusedLabelColor = Color(0xFF60A5FA),
+                            unfocusedLabelColor = Color.White.copy(alpha = 0.58f)
+                        )
+                    )
+
+                    Spacer(modifier = Modifier.height(18.dp))
+
+                    Button(
+                        onClick = {
+                            if (name.isNotBlank()) {
+                                val dao = PulsePlayerDatabase.getDatabase(context).playlistDao()
+                                val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+                                val newPlaylist = Playlist(name = name.trim(), createdAt = formatter.format(Date()))
+
+                                scope.launch {
+                                    withContext(Dispatchers.IO) {
+                                        dao.insert(newPlaylist)
+                                    }
+                                    navController.popBackStack()
+                                }
+                            }
+                        },
+                        enabled = name.isNotBlank(),
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFF9C27B0),
+                            contentColor = Color.White,
+                            disabledContainerColor = Color(0xFF9C27B0).copy(alpha = 0.35f),
+                            disabledContentColor = Color.White.copy(alpha = 0.65f)
+                        )
+                    ) {
+                        Text("Crear lista", fontWeight = FontWeight.Bold, fontSize = 16.sp)
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/pulseplayer/views/playlist/PlaylistDetailsScreen.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/playlist/PlaylistDetailsScreen.kt
@@ -11,12 +11,14 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add // Necesitamos este icono
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -27,6 +29,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import coil.compose.rememberAsyncImagePainter
+import com.example.pulseplayer.AddSongsToPlaylistScreen
 import com.example.pulseplayer.Music
 import com.example.pulseplayer.NowPlaying
 import com.example.pulseplayer.R
@@ -38,10 +41,6 @@ import com.example.pulseplayer.views.viewmodel.PlayerViewModel
 import com.example.pulseplayer.views.viewmodel.PlaylistViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-
-// Importa la nueva ruta de navegación
-import com.example.pulseplayer.AddSongsToPlaylistScreen // <-- ¡Importa tu nueva ruta!
-
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -70,23 +69,24 @@ fun PlaylistDetailsScreen(navController: NavController, playlistId: Int) {
             TopAppBar(
                 title = {
                     Text(
-                        text = playlist?.name ?: "Detalles de la Lista",
+                        text = playlist?.name ?: stringResource(R.string.playlist_screen_title),
                         color = Color.White,
-                        fontSize = 24.sp,
-                        fontWeight = FontWeight.Bold
+                        fontSize = 28.sp,
+                        fontWeight = FontWeight.SemiBold
                     )
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary),
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null, tint = Color.White)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF090B1A)),
             )
         },
-        // ¡Añade el FloatingActionButton aquí!
         floatingActionButton = {
             FloatingActionButton(
-                onClick = {
-                    // Navega a la pantalla para añadir canciones, pasando el ID de la playlist actual
-                        navController.navigate(AddSongsToPlaylistScreen(playlistId = playlistId))
-                },
-                containerColor = Color(0xFF9C27B0), // Color morado similar a tu otro FAB
+                onClick = { navController.navigate(AddSongsToPlaylistScreen(playlistId = playlistId)) },
+                containerColor = Color(0xFF9C27B0),
                 contentColor = Color.White
             ) {
                 Icon(Icons.Default.Add, contentDescription = "Añadir canciones")
@@ -98,13 +98,13 @@ fun PlaylistDetailsScreen(navController: NavController, playlistId: Int) {
                 modifier = Modifier.fillMaxWidth().wrapContentHeight().navigationBarsPadding(),
             )
         },
-        containerColor = MaterialTheme.colorScheme.background,
+        containerColor = Color(0xFF060911),
     ) { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .background(MaterialTheme.colorScheme.background)
+                .background(Color(0xFF060911))
         ) {
             if (songs.isEmpty()) {
                 Box(
@@ -113,14 +113,14 @@ fun PlaylistDetailsScreen(navController: NavController, playlistId: Int) {
                 ) {
                     Text(
                         text = stringResource(R.string.playlist_empty_message2),
-                        color = Color.LightGray,
+                        color = Color.White.copy(alpha = 0.45f),
                         fontSize = 16.sp
                     )
                 }
             } else {
                 LazyColumn(
                     contentPadding = PaddingValues(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
                     modifier = Modifier.fillMaxSize()
                 ) {
                     items(songs) { song ->
@@ -128,10 +128,10 @@ fun PlaylistDetailsScreen(navController: NavController, playlistId: Int) {
                             song = song,
                             isSelected = playerViewModel.currentSong.value?.idSong == song.idSong,
                             onClick = {
-                                val allSongIds = songs.map { it.idSong } // Esto ya es List<Int>
+                                val allSongIds = songs.map { it.idSong }
                                 val startIndex = songs.indexOfFirst { it.idSong == song.idSong }
                                 playerViewModel.playPlaylist(songs, startIndex)
-                                navController.navigate(NowPlaying(song.idSong, allSongIds)) { // <--- ¡CAMBIO AQUÍ! Se pasa directamente allSongIds que ya es List<Int>
+                                navController.navigate(NowPlaying(song.idSong, allSongIds)) {
                                     popUpTo(Music) { inclusive = false }
                                     launchSingleTop = true
                                 }
@@ -147,7 +147,7 @@ fun PlaylistDetailsScreen(navController: NavController, playlistId: Int) {
 @Composable
 fun SongCardItem(song: Song, isSelected: Boolean, onClick: () -> Unit) {
     val borderColor by animateColorAsState(
-        targetValue = if (isSelected) Color(0xFF9C27B0) else Color.Transparent,
+        targetValue = if (isSelected) Color(0xFF9C27B0) else Color.White.copy(alpha = 0.06f),
         label = "borderColor"
     )
 
@@ -155,14 +155,19 @@ fun SongCardItem(song: Song, isSelected: Boolean, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp, vertical = 6.dp)
-            .border(2.dp, borderColor, shape = RoundedCornerShape(16.dp))
+            .border(1.dp, borderColor, shape = RoundedCornerShape(18.dp))
             .clickable { onClick() },
-        colors = CardDefaults.cardColors(containerColor = Color(0xFF1C1C1E)),
-        shape = RoundedCornerShape(16.dp)
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+        shape = RoundedCornerShape(18.dp)
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .background(
+                    brush = Brush.linearGradient(
+                        listOf(Color(0xFF121A31), Color(0xFF0A132B))
+                    )
+                )
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -183,11 +188,10 @@ fun SongCardItem(song: Song, isSelected: Boolean, onClick: () -> Unit) {
 
             Column(modifier = Modifier.weight(1f)) {
                 Text(song.title, color = Color.White, fontSize = 16.sp, fontWeight = FontWeight.Bold)
-                Text(song.artistName, color = Color.LightGray, fontSize = 14.sp)
+                Text(song.artistName, color = Color.White.copy(alpha = 0.58f), fontSize = 14.sp)
             }
 
-            Text(song.formattedDuration, color = Color.White, fontSize = 14.sp)
+            Text(song.formattedDuration, color = Color.White.copy(alpha = 0.9f), fontSize = 14.sp)
         }
     }
 }
-

--- a/app/src/main/java/com/example/pulseplayer/views/playlist/PlaylistScreen.kt
+++ b/app/src/main/java/com/example/pulseplayer/views/playlist/PlaylistScreen.kt
@@ -32,6 +32,7 @@ import com.example.pulseplayer.data.entity.Playlist
 import com.example.pulseplayer.isLandscape
 import com.example.pulseplayer.ui.components.MiniPlayerBar
 import com.example.pulseplayer.views.viewmodel.PlaylistViewModel
+import kotlin.math.absoluteValue
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -153,14 +154,16 @@ fun PlaylistCard(
     onLongClick: () -> Unit,
     onClick: () -> Unit
 ) {
-    val colors = listOf(
-        listOf(Color(0xFFFF416C), Color(0xFFFF4B2B)),
-        listOf(Color(0xFF2193b0), Color(0xFF6dd5ed)),
-        listOf(Color(0xFF7F00FF), Color(0xFFE100FF)),
-        listOf(Color(0xFFff6a00), Color(0xFFee0979)),
-        listOf(Color(0xFF833ab4), Color(0xFFfd1d1d), Color(0xFFfcb045))
+    val gradients = listOf(
+        listOf(Color(0xFF13203C), Color(0xFF0A132B)),
+        listOf(Color(0xFF1A1F4F), Color(0xFF0A1538)),
+        listOf(Color(0xFF1A2552), Color(0xFF0B193B)),
+        listOf(Color(0xFF16235B), Color(0xFF0D1A45)),
+        listOf(Color(0xFF2B1B4A), Color(0xFF131A3D))
     )
-    val gradient = remember { colors.random() }
+    val gradient = remember(playlist.id, playlist.name) {
+        gradients[(playlist.name.hashCode().absoluteValue + playlist.id) % gradients.size]
+    }
 
     Box(
         modifier = Modifier
@@ -168,8 +171,9 @@ fun PlaylistCard(
             .aspectRatio(1f)
             .clip(RoundedCornerShape(16.dp))
             .background(
-                brush = Brush.horizontalGradient(gradient)
+                brush = Brush.linearGradient(gradient)
             )
+            .border(1.dp, Color.White.copy(alpha = 0.08f), RoundedCornerShape(16.dp))
             .combinedClickable(
                 onClick = onClick,
                 onLongClick = onLongClick


### PR DESCRIPTION
### Motivation
- Refresh playlist-related screens with a consistent dark visual style and improved touch targets/spacing.
- Ensure navigation and database operations use coroutines safely by performing DB writes off the main thread and navigating on the main thread.
- Improve playlist card determinism and add form validation for playlist creation.

### Description
- Restyled multiple playlist screens (`PlaylistScreen`, `PlaylistDetailsScreen`, `PlaylistCreateScreen`, `AddSongsToPlaylistScreen`) to use a dark color palette, linear gradient backgrounds, thinner borders, adjusted padding, updated font sizes, and new icons for back/queue actions.
- Reworked card components to use transparent Card container colors, gradient backgrounds with deterministic selection of gradient per playlist, and updated text/icon colors and sizes for improved contrast.
- Updated `PlaylistCreateScreen` to present a styled card with an `OutlinedTextField`, trim the playlist name, enable/disable the create `Button` based on input, and insert new playlists on `Dispatchers.IO` before navigating back on the main thread.
- Fixed `AddSongsToPlaylistScreen` FAB behavior to always use a single FAB with an adjustable modifier for `navigationBarsPadding()`, insert selected songs on `Dispatchers.IO`, and call `navController.popBackStack()` on the main thread after insertion.
- Updated `PlaylistDetailsScreen` navigation to call `NowPlaying` with the computed list of song IDs and minor layout/spacings changes; removed/cleaned some unused imports and organized coroutine usage. 

### Testing
- Ran `./gradlew assembleDebug` to build the debug APK and the build completed successfully. 
- Ran `./gradlew check` (unit tests and lint) and it completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2115abb7c83258020c48a9b7f67e8)